### PR TITLE
Tasks list as result for completionOfAllTasks api.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -122,7 +122,7 @@ __attribute__ ((noinline)) void warnBlockingOperationOnMainThread() {
                         tcs.error = error;
                     }
                 } else {
-                    tcs.result = nil;
+                    tcs.result = tasks;
                 }
             }
             return nil;

--- a/BoltsTests/TaskTests.m
+++ b/BoltsTests/TaskTests.m
@@ -235,6 +235,30 @@
     XCTAssertTrue(task.isCancelled);
 }
 
+- (void)testTaskForCompletionOfAllTasksResult {
+    NSMutableArray *tasks = [NSMutableArray array];
+    
+    const int kTaskCount = 20;
+    for (int i = 0; i < kTaskCount; ++i) {
+        double sleepTimeInMs = rand() % 100;
+        [tasks addObject:[[BFTask taskWithDelay:sleepTimeInMs] continueWithBlock:^id(BFTask *task) {
+            return @(i);
+        }]];
+    }
+    
+    [[[BFTask taskForCompletionOfAllTasks:tasks] continueWithBlock:^id(BFTask *task) {
+        XCTAssertEqual(task.result, tasks);
+        XCTAssertNil(task.error);
+        XCTAssertNil(task.exception);
+        XCTAssertFalse(task.isCancelled);
+        
+        for (int i = 0; i < kTaskCount; ++i) {
+            XCTAssertEqual(i, [((BFTask *)[task result][i]).result intValue]);
+        }
+        return nil;
+    }] waitUntilFinished];
+}
+
 - (void)testTaskForCompletionOfAllTasksSuccess {
     NSMutableArray *tasks = [NSMutableArray array];
     


### PR DESCRIPTION
We had a `nil ` result from `completionOfAllTasks` for the all time. It will be very helpful to have tasks list in next "bolt".
We can found the same idea on the Facebook's [Parse.Promise](https://parse.com/docs/js/symbols/Parse.Promise.html#.when) and [PromiseKit](http://promisekit.org/#synchronizing-with-when) as well.

P.S. New functionality test have been added and CLA have been signed.