### PR TITLE
Increase Size of Hit Targets on BFAppLinkRefererView

### DIFF
--- a/Bolts/iOS/BFAppLinkReturnToRefererView.m
+++ b/Bolts/iOS/BFAppLinkReturnToRefererView.m
@@ -71,6 +71,7 @@ static const CGFloat BFCloseButtonHeight = 12.0;
         _closeButton.userInteractionEnabled = YES;
         _closeButton.clipsToBounds = YES;
         _closeButton.autoresizingMask = UIViewAutoresizingFlexibleLeftMargin | UIViewAutoresizingFlexibleTopMargin;
+        _closeButton.contentMode = UIViewContentModeCenter;
         [_closeButton addTarget:self action:@selector(closeButtonTapped:) forControlEvents:UIControlEventTouchUpInside];
 
         [self addSubview:_closeButton];
@@ -108,14 +109,14 @@ static const CGFloat BFCloseButtonHeight = 12.0;
     CGSize labelSize = [_labelView sizeThatFits:bounds.size];
     _labelView.preferredMaxLayoutWidth = _labelView.bounds.size.width;
     _labelView.frame = CGRectMake(BFMarginX,
-                                  CGRectGetMaxY(bounds) - labelSize.height - BFMarginY,
+                                  CGRectGetMaxY(bounds) - labelSize.height - 1.5 * BFMarginY,
                                   CGRectGetMaxX(bounds) - BFCloseButtonWidth - 3 * BFMarginX,
-                                  labelSize.height);
+                                  labelSize.height + BFMarginY);
 
-    _closeButton.frame = CGRectMake(CGRectGetMaxX(bounds) - BFCloseButtonWidth - BFMarginX,
-                                    _labelView.center.y - BFCloseButtonHeight / 2.0,
-                                    BFCloseButtonWidth,
-                                    BFCloseButtonHeight);
+    _closeButton.frame = CGRectMake(CGRectGetMaxX(bounds) - BFCloseButtonWidth - 2 * BFMarginX,
+                                    _labelView.center.y - BFCloseButtonHeight / 2.0 - BFMarginY,
+                                    BFCloseButtonWidth + 2 * BFMarginX,
+                                    BFCloseButtonHeight + 2 * BFMarginY);
 }
 
 - (CGSize)sizeThatFits:(CGSize)size {
@@ -169,7 +170,7 @@ static const CGFloat BFCloseButtonHeight = 12.0;
     UIImage *closeButtonImage = [self drawCloseButtonImageWithColor:_textColor];
 
     _labelView.textColor = _textColor;
-    [_closeButton setBackgroundImage:closeButtonImage forState:UIControlStateNormal];
+    [_closeButton setImage:closeButtonImage forState:UIControlStateNormal];
 }
 
 - (UIImage *)drawCloseButtonImageWithColor:(UIColor *)color {


### PR DESCRIPTION
Fixes #29. Increases size of hit targets by adding BFMarginY to the top and bottom of both the label and the close button height and also adding BFMarginX to the left and right of the close button width.