### PR TITLE
Release 1.1.4

### DIFF
--- a/Bolts.podspec
+++ b/Bolts.podspec
@@ -1,6 +1,6 @@
 Pod::Spec.new do |s|
   s.name         = "Bolts"
-  s.version      = "1.1.3"
+  s.version      = "1.1.4"
   s.summary      = "Bolts is a collection of low-level libraries designed to make developing mobile apps easier."
   s.description  = <<-DESC
                     Bolts was designed by Parse and Facebook for our own internal use, and we have decided to open source these libraries to make them available to others. Using these libraries does not require using any Parse services. Nor do they require having a Parse or Facebook developer account.

--- a/Bolts/Common/BoltsVersion.h
+++ b/Bolts/Common/BoltsVersion.h
@@ -1,1 +1,1 @@
-#define BOLTS_VERSION @"1.1.3"
+#define BOLTS_VERSION @"1.1.4"

--- a/Bolts/Resources/Mac-Info.plist
+++ b/Bolts/Resources/Mac-Info.plist
@@ -15,11 +15,11 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.1.3</string>
+	<string>1.1.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleVersion</key>
-	<string>$(CURRENT_PROJECT_VERSION)</string>
+	<string>1.1.4</string>
 	<key>NSPrincipalClass</key>
 	<string></string>
 </dict>

--- a/Bolts/Resources/iOS-Info.plist
+++ b/Bolts/Resources/iOS-Info.plist
@@ -13,7 +13,7 @@
 	<key>CFBundlePackageType</key>
 	<string>FMWK</string>
 	<key>CFBundleShortVersionString</key>
-	<string>1.0</string>
+	<string>1.1.4</string>
 	<key>CFBundleSignature</key>
 	<string>????</string>
 	<key>CFBundleSupportedPlatforms</key>
@@ -22,7 +22,7 @@
 		<string>iPhoneOS</string>
 	</array>
 	<key>CFBundleVersion</key>
-	<string>1.0</string>
+	<string>1.1.4</string>
 	<key>MinimumOSVersion</key>
 	<string>5.0</string>
 </dict>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Bolts CHANGELOG
 
+## 1.1.4
+- New: Bolts for iOS is easily importable from Swift code (via `import Bolts`).
+- New: Added `BFTask +taskForCompletionOfAllTaskResults`.
+- New: Added `faulted` property on `BFTask`.
+- New: Made `BFTaskErrorDomain` and `BFTaskMultipleExceptionsException` constants publicly available.
+- New: `BFTask -description` now shows completed/cancelled/faulted status of a task.
+
 ## 1.1.3
 - Made Bolts work if added as a subproject
 - Support for iOS 8


### PR DESCRIPTION
- New: Bolts for iOS is easily importable from Swift code (via `import Bolts`).
- New: Added `BFTask +taskForCompletionOfAllTaskResults`.
- New: Added `faulted` property on `BFTask`.
- New: Made `BFTaskErrorDomain` and `BFTaskMultipleExceptionsException` constants publicly available.
- New: `BFTask -description` now shows completed/cancelled/faulted status of a task.

cc @grantland 