### PR TITLE
Split AppLinks and Tasks into separate subspecs.

### DIFF
--- a/Bolts.podspec
+++ b/Bolts.podspec
@@ -16,12 +16,25 @@ Pod::Spec.new do |s|
   s.documentation_url = 'http://boltsframework.github.io/docs/ios/'
   s.social_media_url = "https://twitter.com/ParseIt"
   s.requires_arc = true
+
+  s.ios.deployment_target = '5.0'
+  s.osx.deployment_target = '10.7'
   
-  s.ios.deployment_target = "5.0"
-  s.ios.source_files = "Bolts/**/*.[hm]"
-  s.ios.public_header_files = "Bolts/**/*.h"
+  s.subspec 'Tasks' do |ss|
+    ss.ios.source_files = 'Bolts/Common/*.[hm]'
+    ss.ios.public_header_files = 'Bolts/Common/*.h'
+    
+    ss.osx.source_files = 'Bolts/Common/*.[hm]'
+    ss.osx.public_header_files = 'Bolts/Common/*.h'
+  end
   
-  s.osx.deployment_target = "10.7"
-  s.osx.source_files = "Bolts/Common/*.[hm]"
-  s.osx.public_header_files = "Bolts/Common/*.h"
+  s.subspec 'AppLinks' do |ss|
+    ss.ios.deployment_target = '5.0'
+    ss.dependency 'Bolts/Tasks'
+    
+    ss.ios.source_files = 'Bolts/iOS/*.[hm]'
+    ss.ios.public_header_files = 'Bolts/iOS/*.h'
+    ss.osx.source_files = ''
+  end
+  
 end

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -13,14 +13,16 @@
 #import <Bolts/BFTask.h>
 #import <Bolts/BFTaskCompletionSource.h>
 
-#if TARGET_OS_IPHONE
+#if __has_include(<Bolts/BFAppLink.h>) && TARGET_OS_IPHONE
 #import <Bolts/BFAppLinkNavigation.h>
 #import <Bolts/BFAppLink.h>
-#import <Bolts/BFAppLinkTarget.h>
-#import <Bolts/BFURL.h>
-#import <Bolts/BFMeasurementEvent.h>
+#import <Bolts/BFAppLinkResolving.h>
 #import <Bolts/BFAppLinkReturnToRefererController.h>
 #import <Bolts/BFAppLinkReturnToRefererView.h>
+#import <Bolts/BFAppLinkTarget.h>
+#import <Bolts/BFMeasurementEvent.h>
+#import <Bolts/BFURL.h>
+#import <Bolts/BFWebViewAppLinkResolver.h>
 #endif
 
 /*! @abstract 80175001: There were multiple errors. */


### PR DESCRIPTION
This splits Bolts podspec into `Bolts/Tasks` and `Bolts/AppLinks`.
Fixes #60 and #80 (though in next release only).