### PR TITLE
Fix: use 'completed' accessor instead of 'isCompleted'

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -306,7 +306,7 @@ __attribute__ ((noinline)) void warnBlockingOperationOnMainThread() {
                 
                 BFTask *resultTask = (BFTask *)result;
                 
-                if (resultTask.isCompleted) {
+                if (resultTask.completed) {
                     setupWithTask(resultTask);
                 } else {
                     [resultTask continueWithBlock:setupWithTask];


### PR DESCRIPTION
Avoid calling the getter directly. Instead use the property name ``completed`` as discussed in a [previous pull request]
[previous pull request]: https://github.com/BoltsFramework/Bolts-iOS/pull/57