### PR TITLE
Fix issue #111

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -336,8 +336,10 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
                 tcs.exception = exception;
                 return;
             }
-
-            if ([result isKindOfClass:[BFTask class]]) {
+            NSString * classString = NSStringFromClass([(BFTask*)result class]);
+            Class resultClass = NSClassFromString(classString);
+            Class selfClass  = [BFTask class];
+            if ([resultClass isSubclassOfClass:selfClass]) {
 
                 id (^setupWithTask) (BFTask *) = ^id(BFTask *task) {
                     if (cancellationToken.cancellationRequested || task.cancelled) {


### PR DESCRIPTION
Proposes a fix for issue #111 

Uses NStringFromClass and NSClassFromString to properly interpret object classes created from Swift.

The bug is actually know by apple.