### PR TITLE
Fixed crash caused when parsing an url with a target_url property set…

### DIFF
--- a/Bolts/iOS/BFURL.m
+++ b/Bolts/iOS/BFURL.m
@@ -54,7 +54,13 @@ FOUNDATION_EXPORT NSString *const BFAppLinkRefererUrl;
                     if (applinkExtras && [applinkExtras isKindOfClass:[NSDictionary class]]) {
                         _appLinkExtras = applinkExtras;
                     }
-                    _targetURL = target ? [NSURL URLWithString:target] : url;
+
+                    if (target == nil || (id)target == [NSNull null]) {
+                        _targetURL = url;
+                    } else {
+                        _targetURL = [NSURL URLWithString:target];
+                    }
+                    
                     _targetQueryParameters = [BFURL queryParametersForURL:_targetURL];
 
                     NSDictionary *refererAppLink = _appLinkData[BFAppLinkRefererAppLink];

--- a/BoltsTests/AppLinkTests.m
+++ b/BoltsTests/AppLinkTests.m
@@ -140,6 +140,15 @@ NSMutableArray *openedUrls = nil;
     XCTAssertEqualObjects(url.absoluteString, openedURL.inputURL.absoluteString);
 }
 
+- (void)testOpenedURLWithAppLinkWithNullTarget {
+    NSURL *url = [NSURL URLWithString:@"bolts://?al_applink_data=%7B%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3anull%7d"];
+    
+    BFURL *openedURL = [BFURL URLWithURL:url];
+    XCTAssertEqualObjects(url.absoluteString, openedURL.targetURL.absoluteString);
+    XCTAssert(openedURL.appLinkData[@"user_agent"]);
+    XCTAssertEqualObjects(url.absoluteString, openedURL.inputURL.absoluteString);
+}
+
 - (void)testOpenedURLWithAppLinkTargetHasQueryParameters {
     NSURL *url = [NSURL URLWithString:@"bolts://?al_applink_data=%7B%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22http%3A%5C%2F%5C%2Fwww.example.com%5C%2Fpath%3Ffoo%3Dbar%22%7D"];
 


### PR DESCRIPTION
… to null in applinks resulting in a NSNull object improperly considered as valid NSString

I had this issue with Facebook hosted applinks returning a null target_url like described below 
bolts://?al_applink_data={"user_agent":"Bolts iOS 1.0.0","target_url":null}

Note that in this case, null value is resulting in a NSNull object by NSJSONSerialization parser.