### PR TITLE
Build only master for pushes on Travis-CI.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,3 +1,6 @@
+branches:
+  only:
+    - master
 language: objective-c
 osx_image: xcode6.4
 cache: 


### PR DESCRIPTION
This disables builds on all other branches except of master to reduce churn.
Pull Requests will still continue to build, tho.