### PR TITLE
Fixed deprecations in iOS 9 that cause warnings.

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -912,6 +912,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNKNOWN_PRAGMAS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				ONLY_ACTIVE_ARCH = YES;
 			};
 			name = Debug;
@@ -944,6 +946,8 @@
 				GCC_WARN_UNINITIALIZED_AUTOS = YES;
 				GCC_WARN_UNKNOWN_PRAGMAS = YES;
 				GCC_WARN_UNUSED_VARIABLE = YES;
+				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
+				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				VALIDATE_PRODUCT = YES;
 			};
 			name = Release;
@@ -960,8 +964,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Bolts/Bolts-Prefix.pch";
 				INFOPLIST_FILE = "Bolts/Resources/iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[arch=arm64]" = 6.0;
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = Bolts/Resources/iOS.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
@@ -983,8 +985,6 @@
 				GCC_PRECOMPILE_PREFIX_HEADER = YES;
 				GCC_PREFIX_HEADER = "Bolts/Bolts-Prefix.pch";
 				INFOPLIST_FILE = "Bolts/Resources/iOS-Info.plist";
-				IPHONEOS_DEPLOYMENT_TARGET = 5.0;
-				"IPHONEOS_DEPLOYMENT_TARGET[arch=arm64]" = 6.0;
 				MACH_O_TYPE = staticlib;
 				MODULEMAP_FILE = Bolts/Resources/iOS.modulemap;
 				OTHER_LDFLAGS = "-ObjC";
@@ -1006,7 +1006,6 @@
 				GCC_PREFIX_HEADER = "Bolts/Bolts-Prefix.pch";
 				INFOPLIST_FILE = "Bolts/Resources/Mac-Info.plist";
 				MACH_O_TYPE = mh_dylib;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Bolts;
 				SDKROOT = macosx;
@@ -1026,7 +1025,6 @@
 				GCC_PREFIX_HEADER = "Bolts/Bolts-Prefix.pch";
 				INFOPLIST_FILE = "Bolts/Resources/Mac-Info.plist";
 				MACH_O_TYPE = mh_dylib;
-				MACOSX_DEPLOYMENT_TARGET = 10.7;
 				OTHER_LDFLAGS = "-ObjC";
 				PRODUCT_NAME = Bolts;
 				SDKROOT = macosx;

--- a/Bolts/iOS/BFAppLinkNavigation.m
+++ b/Bolts/iOS/BFAppLinkNavigation.m
@@ -49,11 +49,15 @@ static id<BFAppLinkResolving> defaultResolver;
 }
 
 - (NSString *)stringByEscapingQueryString:(NSString *)string {
+#if __IPHONE_OS_VERSION_MIN_REQUIRED >= __IPHONE_7_0 || __MAC_OS_X_VERSION_MIN_REQUIRED >= __MAC_10_9
+    return [string stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]];
+#else
     return (NSString *)CFBridgingRelease(CFURLCreateStringByAddingPercentEscapes(NULL,
                                                                                  (CFStringRef)string,
                                                                                  NULL,
                                                                                  (CFStringRef) @":/?#[]@!$&'()*+,;=",
                                                                                  kCFStringEncodingUTF8));
+#endif
 }
 
 - (NSURL *)appLinkURLWithTargetURL:(NSURL *)targetUrl error:(NSError **)error {


### PR DESCRIPTION
These were deprecated in iOS 9 and are causing warnings to appear.
Use newly available methods if compiling for the latest platform and not having backwards compatibility.
cc @richardjrossiii

Fixes #126