### PR TITLE
Fixed crash when creating a BFURL when target_url is null.

### DIFF
--- a/Bolts/iOS/BFURL.m
+++ b/Bolts/iOS/BFURL.m
@@ -54,7 +54,7 @@ FOUNDATION_EXPORT NSString *const BFAppLinkRefererUrl;
                     if (applinkExtras && [applinkExtras isKindOfClass:[NSDictionary class]]) {
                         _appLinkExtras = applinkExtras;
                     }
-                    _targetURL = target ? [NSURL URLWithString:target] : url;
+                    _targetURL = ([target isKindOfClass:[NSString class]] ? [NSURL URLWithString:target] : url);
                     _targetQueryParameters = [BFURL queryParametersForURL:_targetURL];
 
                     NSDictionary *refererAppLink = _appLinkData[BFAppLinkRefererAppLink];

--- a/BoltsTests/AppLinkTests.m
+++ b/BoltsTests/AppLinkTests.m
@@ -179,6 +179,16 @@ NSMutableArray *openedUrls = nil;
     XCTAssertEqualObjects(url.absoluteString, openedURL.inputURL.absoluteString);
 }
 
+- (void)testOpenedURLWithBadTarget {
+    NSURL *url = [NSURL URLWithString:@"bolts://?al_applink_data=%7B%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3Anull%7D"];
+
+    BFURL *openedURL = [BFURL URLWithURL:url];
+
+    XCTAssertEqualObjects(url, openedURL.targetURL);
+    XCTAssert(openedURL.appLinkData[@"user_agent"]);
+    XCTAssertEqualObjects(url.absoluteString, openedURL.inputURL.absoluteString);
+}
+
 - (void)testOpenedIncomingURLWithAppLinkWillPostEvent {
     NSURL *url = [NSURL URLWithString:@"bolts://?foo=bar&al_applink_data=%7B%22a%22%3A%22b%22%2C%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22http%3A%5C%2F%5C%2Fwww.example.com%5C%2Fpath%3Fbaz%3Dbat%22%7D"];
     NSString *sourceApplication = @"com.example.referer";


### PR DESCRIPTION
Verify that the string is actually a string. This eliminates potential problems like if the URL is a number or anything else shady.
Fixes #114.