### PR TITLE
Fixed handling of BFIncludeStatusBarInSizeAlways

### DIFF
--- a/Bolts/iOS/BFAppLinkReturnToRefererView.m
+++ b/Bolts/iOS/BFAppLinkReturnToRefererView.m
@@ -146,7 +146,7 @@ static const CGFloat BFCloseButtonHeight = 12.0;
     BOOL include;
     switch (_includeStatusBarInSize) {
         case BFIncludeStatusBarInSizeAlways:
-            include = NO;
+            include = YES;
             break;
         case BFIncludeStatusBarInSizeIOS7AndLater: {
             float systemVersion = [[[UIDevice currentDevice] systemVersion] floatValue];

--- a/BoltsTests/AppLinkReturnToRefererViewTests.m
+++ b/BoltsTests/AppLinkReturnToRefererViewTests.m
@@ -74,17 +74,30 @@ static NSString *const BFURLWithRefererNameNoUrl = @"bolts://?foo=bar&al_applink
     XCTAssert(sizeThatFits.width > 0.0);
 }
 
+- (void)testIncludesStatusBarResultsInLargerHeight {
+    NSURL *url = [NSURL URLWithString:BFURLWithRefererData];
+    BFAppLink *appLink = [[BFURL URLWithURL:url] appLinkReferer];
+
+    BFAppLinkReturnToRefererView *view = [[BFAppLinkReturnToRefererView alloc] init];
+    view.refererAppLink = appLink;
+    view.includeStatusBarInSize = BFIncludeStatusBarInSizeNever;
+    CGSize sizeThatFitsNotIncludingStatusBar = [view sizeThatFits:CGSizeMake(100.0, 100.0)];
+
+    view.includeStatusBarInSize = BFIncludeStatusBarInSizeAlways;
+    CGSize sizeThatFitsIncludingStatusBar = [view sizeThatFits:CGSizeMake(100.0, 100.0)];
+
+    XCTAssert(sizeThatFitsIncludingStatusBar.height > sizeThatFitsNotIncludingStatusBar.height);
+}
+
 - (void)testNotIncludingStatusBarResultsInSmallerHeight {
     NSURL *url = [NSURL URLWithString:BFURLWithRefererData];
     BFAppLink *appLink = [[BFURL URLWithURL:url] appLinkReferer];
 
     BFAppLinkReturnToRefererView *view = [[BFAppLinkReturnToRefererView alloc] init];
     view.refererAppLink = appLink;
-
     CGSize sizeThatFitsIncludingStatusBar = [view sizeThatFits:CGSizeMake(100.0, 100.0)];
 
     view.includeStatusBarInSize = BFIncludeStatusBarInSizeNever;
-
     CGSize sizeThatFitsNotIncludingStatusBar = [view sizeThatFits:CGSizeMake(100.0, 100.0)];
 
     XCTAssert(sizeThatFitsIncludingStatusBar.height > sizeThatFitsNotIncludingStatusBar.height);


### PR DESCRIPTION
When includeStatusBarInSize was set to BFIncludeStatusBarInSizeAlways, it didn't actually include the status bar in its size.