### PR TITLE
Fix command line build scripts when bolts is contained in paths with spaces.

### DIFF
--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -66,29 +66,29 @@ progress_message Building Framework.
 # -----------------------------------------------------------------------------
 # Compile binaries 
 #
-test -d $BOLTS_BUILD \
-  || mkdir -p $BOLTS_BUILD \
+test -d "$BOLTS_BUILD" \
+  || mkdir -p "$BOLTS_BUILD" \
   || die "Could not create directory $BOLTS_BUILD"
 
-test -d $BOLTS_IOS_BUILD \
-  || mkdir -p $BOLTS_IOS_BUILD \
+test -d "$BOLTS_IOS_BUILD" \
+  || mkdir -p "$BOLTS_IOS_BUILD" \
   || die "Could not create directory $BOLTS_IOS_BUILD"
 
-test -d $BOLTS_OSX_BUILD \
-  || mkdir -p $BOLTS_OSX_BUILD \
+test -d "$BOLTS_OSX_BUILD" \
+  || mkdir -p "$BOLTS_OSX_BUILD" \
   || die "Could not create directory $BOLTS_OSX_BUILD"
 
-cd $BOLTS_SRC
+cd "$BOLTS_SRC"
 function xcode_build_target() {
   echo "Compiling for platform: ${1}."
   $XCODEBUILD \
     -target "${3}Bolts" \
     -sdk $1 \
     -configuration "${2}" \
-    SYMROOT=$BOLTS_BUILD \
-    CURRENT_PROJECT_VERSION=$BOLTS_VERSION_FULL \
+    SYMROOT="$BOLTS_BUILD" \
+    CURRENT_PROJECT_VERSION="$BOLTS_VERSION_FULL" \
     clean build \
-    || die "XCode build failed for platform: ${1}."
+    || die "Xcode build failed for platform: ${1}."
 }
 
 xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}"
@@ -100,7 +100,7 @@ xcode_build_target "macosx" "${BUILDCONFIGURATION}" "Mac"
 #
 progress_message "Building Bolts univeral library using lipo."
 
-mkdir -p $(dirname $BOLTS_IOS_BINARY)
+mkdir -p "$(dirname "$BOLTS_IOS_BINARY")"
 
 # Copy/Paste iOS Framework to get structure/resources/etc
 cp -av \
@@ -111,13 +111,13 @@ rm "$BOLTS_BUILD/${BUILDCONFIGURATION}-universal/Bolts.framework/Bolts"
 # Combine iOS/Simulator binaries into a single universal binary.
 $LIPO \
   -create \
-    $BOLTS_BUILD/${BUILDCONFIGURATION}-iphonesimulator/Bolts.framework/Bolts \
-    $BOLTS_BUILD/${BUILDCONFIGURATION}-iphoneos/Bolts.framework/Bolts \
-  -output $BOLTS_IOS_BINARY \
+    "$BOLTS_BUILD/${BUILDCONFIGURATION}-iphonesimulator/Bolts.framework/Bolts" \
+    "$BOLTS_BUILD/${BUILDCONFIGURATION}-iphoneos/Bolts.framework/Bolts" \
+  -output "$BOLTS_IOS_BINARY" \
   || die "lipo failed - could not create universal static library"
 
 # Copy/Paste created iOS Framework to final location
-cp -av "$(dirname $BOLTS_IOS_BINARY)" "$BOLTS_IOS_FRAMEWORK"
+cp -av "$(dirname "$BOLTS_IOS_BINARY")" "$BOLTS_IOS_FRAMEWORK"
 
 # Copy/Paste OSX framework, as this is already built for us
 cp -av "$BOLTS_OSX_BINARY" "$BOLTS_OSX_FRAMEWORK"

--- a/scripts/common.sh
+++ b/scripts/common.sh
@@ -34,12 +34,12 @@ if [ -z "$BOLTS_SCRIPT" ]; then
 
   # The directory containing this script
   # We need to go there and use pwd so these are all absolute paths
-  pushd $(dirname $BASH_SOURCE[0]) >/dev/null
-  BOLTS_SCRIPT=$(pwd)
+  pushd "$(dirname $BASH_SOURCE[0])" >/dev/null
+  BOLTS_SCRIPT="$(pwd)"
   popd >/dev/null
 
   # The root directory where Bolts is cloned
-  BOLTS_ROOT=$(dirname $BOLTS_SCRIPT)
+  BOLTS_ROOT=$(dirname "$BOLTS_SCRIPT")
 
   # Path to source files for Bolts
   BOLTS_SRC=$BOLTS_ROOT
@@ -76,7 +76,7 @@ if [ -z $BOLTS_ENV ]; then
   # Explains where the log is if this is the outermost build or if
   # we hit a fatal error.
   function show_summary() {
-    test -r $BOLTS_BUILD_LOG && echo "Build log is at $BOLTS_BUILD_LOG"
+    test -r "$BOLTS_BUILD_LOG" && echo "Build log is at $BOLTS_BUILD_LOG"
   }
 
   # Determines whether this is out the outermost build.


### PR DESCRIPTION
Our scripts were failing when Bolts clone is in a path that has spaces - this fixes it.