### PR TITLE
Add backward compatible Obj-C Generic support for Tasks.

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -44,6 +44,8 @@
 		8103FA7819900A84000BAE3F /* BFAppLinkTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6319900A84000BAE3F /* BFAppLinkTarget.m */; };
 		8103FA7A19900A84000BAE3F /* BFURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6519900A84000BAE3F /* BFURL.m */; };
 		8103FA7C19900A84000BAE3F /* BFWebViewAppLinkResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6719900A84000BAE3F /* BFWebViewAppLinkResolver.m */; };
+		8105DA251B7A83BC0092AE4F /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8105DA261B7A83BC0092AE4F /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8122B2871AA0C6890025C5AF /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDDA63517E17DDD00655F8A /* Bolts.framework */; };
 		81D0EE7D19AFA8260000AE75 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81D0EE7C19AFA8260000AE75 /* UIKit.framework */; };
 		81D0EE8019AFA9E20000AE75 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -148,6 +150,7 @@
 		8103FA6519900A84000BAE3F /* BFURL.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BFURL.m; sourceTree = "<group>"; };
 		8103FA6619900A84000BAE3F /* BFWebViewAppLinkResolver.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BFWebViewAppLinkResolver.h; sourceTree = "<group>"; };
 		8103FA6719900A84000BAE3F /* BFWebViewAppLinkResolver.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BFWebViewAppLinkResolver.m; sourceTree = "<group>"; };
+		8105DA241B7A83BC0092AE4F /* BFDefines.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BFDefines.h; sourceTree = "<group>"; };
 		8122B2881AA0E8220025C5AF /* iOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "iOS-Info.plist"; path = "Resources/iOS-Info.plist"; sourceTree = "<group>"; };
 		81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Bolts-iOS.xcconfig"; sourceTree = "<group>"; };
 		81279F731B9A3F06006696C2 /* Bolts-OSX.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Bolts-OSX.xcconfig"; sourceTree = "<group>"; };
@@ -263,6 +266,7 @@
 				8103FA5619900A84000BAE3F /* BoltsVersion.h */,
 				8103FA5419900A84000BAE3F /* Bolts.h */,
 				8103FA5519900A84000BAE3F /* Bolts.m */,
+				8105DA241B7A83BC0092AE4F /* BFDefines.h */,
 				8103FA5019900A84000BAE3F /* BFTask.h */,
 				8103FA5119900A84000BAE3F /* BFTask.m */,
 				8103FA5219900A84000BAE3F /* BFTaskCompletionSource.h */,
@@ -461,6 +465,7 @@
 				81D0EE8019AFA9E20000AE75 /* BoltsVersion.h in Headers */,
 				81D0EE8C19AFAA5F0000AE75 /* BFAppLink.h in Headers */,
 				81D0EE9219AFAA6F0000AE75 /* BFMeasurementEvent.h in Headers */,
+				8105DA251B7A83BC0092AE4F /* BFDefines.h in Headers */,
 				81D0EE9319AFAA6F0000AE75 /* BFURL.h in Headers */,
 				7CA39C921ADE715400DD78CC /* BFCancellationTokenRegistration.h in Headers */,
 				81D0EE8419AFAA100000AE75 /* Bolts.h in Headers */,
@@ -476,6 +481,7 @@
 				81D0EE8519AFAA190000AE75 /* BFTask.h in Headers */,
 				7C60AECA1ACF1A0B00747DD7 /* BFCancellationTokenSource.h in Headers */,
 				81D0EE8819AFAA240000AE75 /* BFExecutor.h in Headers */,
+				8105DA261B7A83BC0092AE4F /* BFDefines.h in Headers */,
 				81D0EE8A19AFAA2C0000AE75 /* BFTaskCompletionSource.h in Headers */,
 				81D0EE8219AFAA060000AE75 /* BoltsVersion.h in Headers */,
 				81D0EE8319AFAA0E0000AE75 /* Bolts.h in Headers */,

--- a/Bolts/Common/BFDefines.h
+++ b/Bolts/Common/BFDefines.h
@@ -1,0 +1,18 @@
+/*
+ *  Copyright (c) 2014, Facebook, Inc.
+ *  All rights reserved.
+ *
+ *  This source code is licensed under the BSD-style license found in the
+ *  LICENSE file in the root directory of this source tree. An additional grant
+ *  of patent rights can be found in the PATENTS file in the same directory.
+ *
+ */
+
+#import <Foundation/Foundation.h>
+
+#if __has_feature(objc_generics) || __has_extension(objc_generics)
+#  define BF_GENERIC(type) <type>
+#else
+#  define BF_GENERIC(type)
+#  define BFGenericType id
+#endif

--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -11,6 +11,7 @@
 #import <Foundation/Foundation.h>
 
 #import <Bolts/BFCancellationToken.h>
+#import <Bolts/BFDefines.h>
 
 /*!
  Error domain used if there was multiple errors on <BFTask taskForCompletionOfAllTasks:>.
@@ -26,22 +27,22 @@ extern NSString *const BFTaskMultipleExceptionsException;
 @class BFTask;
 
 /*!
- A block that can act as a continuation for a task.
- */
-typedef id(^BFContinuationBlock)(BFTask *task);
-
-/*!
  The consumer view of a Task. A BFTask has methods to
  inspect the state of the task, and to add continuations to
  be run once the task is complete.
  */
-@interface BFTask : NSObject
+@interface BFTask BF_GENERIC(__covariant BFGenericType) : NSObject
+
+/*!
+ A block that can act as a continuation for a task.
+ */
+typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
 
 /*!
  Creates a task that is already completed with the given result.
  @param result The result for the task.
  */
-+ (instancetype)taskWithResult:(id)result;
++ (instancetype)taskWithResult:(BFGenericType)result;
 
 /*!
  Creates a task that is already completed with the given error.
@@ -109,7 +110,7 @@ typedef id(^BFContinuationBlock)(BFTask *task);
 /*!
  The result of a successful task.
  */
-@property (nonatomic, strong, readonly) id result;
+@property (nonatomic, strong, readonly) BFGenericType result;
 
 /*!
  The error of a failed task.

--- a/Bolts/Common/BFTaskCompletionSource.h
+++ b/Bolts/Common/BFTaskCompletionSource.h
@@ -10,14 +10,16 @@
 
 #import <Foundation/Foundation.h>
 
-@class BFTask;
+#import <Bolts/BFDefines.h>
+
+@class BFTask BF_GENERIC(BFGenericType);
 
 /*!
  A BFTaskCompletionSource represents the producer side of tasks.
  It is a task that also has methods for changing the state of the
  task by settings its completion values.
  */
-@interface BFTaskCompletionSource : NSObject
+@interface BFTaskCompletionSource BF_GENERIC(__covariant BFGenericType) : NSObject
 
 /*!
  Creates a new unfinished task.
@@ -27,14 +29,14 @@
 /*!
  The task associated with this TaskCompletionSource.
  */
-@property (nonatomic, strong, readonly) BFTask *task;
+@property (nonatomic, strong, readonly) BFTask BF_GENERIC(BFGenericType) *task;
 
 /*!
  Completes the task by setting the result.
  Attempting to set this for a completed task will raise an exception.
  @param result The result of the task.
  */
-- (void)setResult:(id)result;
+- (void)setResult:(BFGenericType)result;
 
 /*!
  Completes the task by setting the error.
@@ -60,7 +62,7 @@
  Sets the result of the task if it wasn't already completed.
  @returns whether the new value was set.
  */
-- (BOOL)trySetResult:(id)result;
+- (BOOL)trySetResult:(BFGenericType)result;
 
 /*!
  Sets the error of the task if it wasn't already completed.

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -12,6 +12,7 @@
 #import <Bolts/BFCancellationToken.h>
 #import <Bolts/BFCancellationTokenRegistration.h>
 #import <Bolts/BFCancellationTokenSource.h>
+#import <Bolts/BFDefines.h>
 #import <Bolts/BFExecutor.h>
 #import <Bolts/BFTask.h>
 #import <Bolts/BFTaskCompletionSource.h>


### PR DESCRIPTION
This support latest syntax in Xcode 7, and also is backward compatible via macro.
cc @grantland, @hallucinogen, @richardjrossiii