### PR TITLE
Add bitcode support to precompiled frameworks on iOS 9.

### DIFF
--- a/Configurations/Bolts-iOS.xcconfig
+++ b/Configurations/Bolts-iOS.xcconfig
@@ -16,6 +16,9 @@ MACH_O_TYPE = staticlib
 
 DEFINES_MODULE = YES
 MODULEMAP_FILE = $(SRCROOT)/Bolts/Resources/iOS.modulemap
-OTHER_LD_FLAGS = -ObjC
+
+BF_BITCODE_FLAG = $()
+BF_BITCODE_FLAG[sdk=iphoneos9.0] = -fembed-bitcode
+OTHER_LD_FLAGS = -ObjC $(BF_BITCODE_FLAG)
 
 INFOPLIST_FILE = $(SRCROOT)/Bolts/Resources/iOS-Info.plist


### PR DESCRIPTION
Add the bitcode support if the binary is compiled with a iOS 9 SDK.
Please note that enabling this for iphonesimulator is not required and will break Xcode 6.4

cc @grantland @richardjrossiii