### PR TITLE
Update bitcode flag resolution for Xcode 7 GM.

### DIFF
--- a/Configurations/Bolts-iOS.xcconfig
+++ b/Configurations/Bolts-iOS.xcconfig
@@ -17,8 +17,8 @@ MACH_O_TYPE = staticlib
 DEFINES_MODULE = YES
 MODULEMAP_FILE = $(SRCROOT)/Bolts/Resources/iOS.modulemap
 
-BF_BITCODE_FLAG = $()
-BF_BITCODE_FLAG[sdk=iphoneos9.0] = -fembed-bitcode
-OTHER_LD_FLAGS = -ObjC $(BF_BITCODE_FLAG)
+OTHER_CFLAGS[sdk=iphoneos9.0] = $(inherited) -fembed-bitcode
+
+OTHER_LDFLAGS = $(inherited) -ObjC
 
 INFOPLIST_FILE = $(SRCROOT)/Bolts/Resources/iOS-Info.plist


### PR DESCRIPTION
This properly builds and emits bitcode in code when built using Xcode 7 GM.
Tested the built framework against both Xcode 6.4 and 7.0 GM.
It also outputs `bitcode` slice into the binary, which could be observed by running `otool -l ...`