### PR TITLE
Fixed undefined behavior caused by casting block types.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -170,7 +170,9 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 
 + (instancetype)taskFromExecutor:(BFExecutor *)executor
                        withBlock:(id (^)())block {
-    return [[self taskWithResult:nil] continueWithExecutor:executor withBlock:block];
+    return [[self taskWithResult:nil] continueWithExecutor:executor withBlock:^id(BFTask *task) {
+        return block();
+    }];
 }
 
 #pragma mark - Custom Setters/Getters


### PR DESCRIPTION
Simple issue, you can't just cast a block type to another and expect it to work on every arch. For archs like PPC, this could have devastating stack-smashing side effects. Luckily, x86, ARM & friends are much nicer.