### PR TITLE
Added watchOS 2 target.

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -47,6 +47,23 @@
 		8105DA251B7A83BC0092AE4F /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8105DA261B7A83BC0092AE4F /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8122B2871AA0C6890025C5AF /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDDA63517E17DDD00655F8A /* Bolts.framework */; };
+		8178F9861BB0F87700AD289D /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
+		8178F9871BB0F87700AD289D /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
+		8178F9881BB0F87700AD289D /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
+		8178F9891BB0F87700AD289D /* BFCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA39C911ADE715400DD78CC /* BFCancellationTokenRegistration.m */; };
+		8178F98A1BB0F87700AD289D /* BFCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC21ACF093D00747DD7 /* BFCancellationTokenSource.m */; };
+		8178F98B1BB0F87700AD289D /* BFExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA4F19900A84000BAE3F /* BFExecutor.m */; };
+		8178F98C1BB0F87700AD289D /* BFCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEBE1ACF08F300747DD7 /* BFCancellationToken.m */; };
+		8178F98E1BB0F87700AD289D /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
+		8178F9901BB0F87700AD289D /* BFCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CA39C901ADE715400DD78CC /* BFCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9911BB0F87700AD289D /* BFTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5019900A84000BAE3F /* BFTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9921BB0F87700AD289D /* BFCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEC11ACF093D00747DD7 /* BFCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9931BB0F87700AD289D /* BFExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA4E19900A84000BAE3F /* BFExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9941BB0F87700AD289D /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9951BB0F87700AD289D /* BFTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5219900A84000BAE3F /* BFTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9961BB0F87700AD289D /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9971BB0F87700AD289D /* Bolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5419900A84000BAE3F /* Bolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		8178F9981BB0F87700AD289D /* BFCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEBD1ACF08F300747DD7 /* BFCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE7D19AFA8260000AE75 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81D0EE7C19AFA8260000AE75 /* UIKit.framework */; };
 		81D0EE8019AFA9E20000AE75 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE8219AFAA060000AE75 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
@@ -196,6 +213,10 @@
 		81279F811B9A3F06006696C2 /* Release.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Release.xcconfig; sourceTree = "<group>"; };
 		81279F831B9A3F06006696C2 /* Warnings.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = Warnings.xcconfig; sourceTree = "<group>"; };
 		814916E11AD5D46600EE7C63 /* iOS.modulemap */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = "sourcecode.module-map"; name = iOS.modulemap; path = Resources/iOS.modulemap; sourceTree = "<group>"; };
+		8178F9821BB0F83C00AD289D /* watchOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = watchOS.xcconfig; sourceTree = "<group>"; };
+		8178F9831BB0F86000AD289D /* Bolts-watchOS.xcconfig */ = {isa = PBXFileReference; lastKnownFileType = text.xcconfig; path = "Bolts-watchOS.xcconfig"; sourceTree = "<group>"; };
+		8178F99C1BB0F87700AD289D /* Bolts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bolts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		8178F99E1BB0F8A600AD289D /* watchOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "watchOS-Info.plist"; path = "Resources/watchOS-Info.plist"; sourceTree = "<group>"; };
 		81D0EE7C19AFA8260000AE75 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		81DC1A611B7A7F4000F491DC /* ExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExecutorTests.m; sourceTree = "<group>"; };
 		81F0E88D19E5CB5A00812A88 /* Mac-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "Mac-Info.plist"; path = "Resources/Mac-Info.plist"; sourceTree = "<group>"; };
@@ -233,6 +254,14 @@
 				81D0EE7D19AFA8260000AE75 /* UIKit.framework in Frameworks */,
 				1EC3016318CDAA8400D06D07 /* CoreGraphics.framework in Frameworks */,
 				1EC3016118CDAA8400D06D07 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8178F98D1BB0F87700AD289D /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8178F98E1BB0F87700AD289D /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -370,6 +399,7 @@
 				81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */,
 				81279F731B9A3F06006696C2 /* Bolts-OSX.xcconfig */,
 				F5AFCA151BA752AF0076E927 /* Bolts-tvOS.xcconfig */,
+				8178F9831BB0F86000AD289D /* Bolts-watchOS.xcconfig */,
 				81279F741B9A3F06006696C2 /* BoltsTests-iOS.xcconfig */,
 				81279F751B9A3F06006696C2 /* BoltsTests-OSX.xcconfig */,
 				F5AFCA161BA752D30076E927 /* BoltsTests-tvOS.xcconfig */,
@@ -396,6 +426,7 @@
 				81279F791B9A3F06006696C2 /* iOS.xcconfig */,
 				81279F7A1B9A3F06006696C2 /* OSX.xcconfig */,
 				F5AFCA171BA752F90076E927 /* tvOS.xcconfig */,
+				8178F9821BB0F83C00AD289D /* watchOS.xcconfig */,
 			);
 			path = Platform;
 			sourceTree = "<group>";
@@ -466,6 +497,7 @@
 				1EC3016018CDAA8400D06D07 /* BoltsTestUI.app */,
 				F5AFCA021BA752750076E927 /* Bolts.framework */,
 				F5AFCA131BA752770076E927 /* BoltsTests-tvOS.xctest */,
+				8178F99C1BB0F87700AD289D /* Bolts.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -500,6 +532,7 @@
 				8122B2881AA0E8220025C5AF /* iOS-Info.plist */,
 				81F0E88D19E5CB5A00812A88 /* Mac-Info.plist */,
 				F5AFCA181BA753D20076E927 /* tvOS-Info.plist */,
+				8178F99E1BB0F8A600AD289D /* watchOS-Info.plist */,
 			);
 			name = "Supporting Files";
 			sourceTree = "<group>";
@@ -507,6 +540,22 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		8178F98F1BB0F87700AD289D /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8178F9901BB0F87700AD289D /* BFCancellationTokenRegistration.h in Headers */,
+				8178F9911BB0F87700AD289D /* BFTask.h in Headers */,
+				8178F9921BB0F87700AD289D /* BFCancellationTokenSource.h in Headers */,
+				8178F9931BB0F87700AD289D /* BFExecutor.h in Headers */,
+				8178F9941BB0F87700AD289D /* BFDefines.h in Headers */,
+				8178F9951BB0F87700AD289D /* BFTaskCompletionSource.h in Headers */,
+				8178F9961BB0F87700AD289D /* BoltsVersion.h in Headers */,
+				8178F9971BB0F87700AD289D /* Bolts.h in Headers */,
+				8178F9981BB0F87700AD289D /* BFCancellationToken.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		81D0EE7F19AFA9BC0000AE75 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -583,6 +632,23 @@
 			productName = BoltsTestUI;
 			productReference = 1EC3016018CDAA8400D06D07 /* BoltsTestUI.app */;
 			productType = "com.apple.product-type.application";
+		};
+		8178F9841BB0F87700AD289D /* Bolts-watchOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 8178F9991BB0F87700AD289D /* Build configuration list for PBXNativeTarget "Bolts-watchOS" */;
+			buildPhases = (
+				8178F9851BB0F87700AD289D /* Sources */,
+				8178F98D1BB0F87700AD289D /* Frameworks */,
+				8178F98F1BB0F87700AD289D /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Bolts-watchOS";
+			productName = Bolts;
+			productReference = 8178F99C1BB0F87700AD289D /* Bolts.framework */;
+			productType = "com.apple.product-type.framework";
 		};
 		8E8C8EE817F23D1D00E3F1C7 /* BoltsTests */ = {
 			isa = PBXNativeTarget;
@@ -696,12 +762,9 @@
 		8E9C3CE117DE9DE000427E62 /* Project object */ = {
 			isa = PBXProject;
 			attributes = {
-				LastUpgradeCheck = 0630;
+				LastUpgradeCheck = 0700;
 				ORGANIZATIONNAME = "Parse Inc.";
 				TargetAttributes = {
-					8E8C8EE817F23D1D00E3F1C7 = {
-						TestTargetID = 1EC3015F18CDAA8300D06D07;
-					};
 					8E8C8F1817F241DA00E3F1C7 = {
 						TestTargetID = 8EDDA62817E17DDC00655F8A;
 					};
@@ -722,6 +785,7 @@
 				8E9C3CE817DE9DE000427E62 /* Bolts */,
 				8EDDA62817E17DDC00655F8A /* MacBolts */,
 				F5AFC9EA1BA752750076E927 /* TVBolts */,
+				8178F9841BB0F87700AD289D /* Bolts-watchOS */,
 				8E8C8EE817F23D1D00E3F1C7 /* BoltsTests */,
 				8E8C8F1817F241DA00E3F1C7 /* MacBoltsTests */,
 				F5AFCA041BA752770076E927 /* TVBoltsTests */,
@@ -771,6 +835,20 @@
 			files = (
 				1EC3017118CDAA8400D06D07 /* AppDelegate.m in Sources */,
 				1EC3016D18CDAA8400D06D07 /* main.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		8178F9851BB0F87700AD289D /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				8178F9861BB0F87700AD289D /* BFTaskCompletionSource.m in Sources */,
+				8178F9871BB0F87700AD289D /* BFTask.m in Sources */,
+				8178F9881BB0F87700AD289D /* Bolts.m in Sources */,
+				8178F9891BB0F87700AD289D /* BFCancellationTokenRegistration.m in Sources */,
+				8178F98A1BB0F87700AD289D /* BFCancellationTokenSource.m in Sources */,
+				8178F98B1BB0F87700AD289D /* BFExecutor.m in Sources */,
+				8178F98C1BB0F87700AD289D /* BFCancellationToken.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -965,6 +1043,20 @@
 			};
 			name = Release;
 		};
+		8178F99A1BB0F87700AD289D /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8178F9831BB0F86000AD289D /* Bolts-watchOS.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		8178F99B1BB0F87700AD289D /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 8178F9831BB0F86000AD289D /* Bolts-watchOS.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		8E8C8EF917F23D1D00E3F1C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81279F741B9A3F06006696C2 /* BoltsTests-iOS.xcconfig */;
@@ -1071,6 +1163,15 @@
 			buildConfigurations = (
 				1EC3018618CDAA8400D06D07 /* Debug */,
 				1EC3018818CDAA8400D06D07 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
+		8178F9991BB0F87700AD289D /* Build configuration list for PBXNativeTarget "Bolts-watchOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				8178F99A1BB0F87700AD289D /* Debug */,
+				8178F99B1BB0F87700AD289D /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-watchOS.xcscheme
+++ b/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-watchOS.xcscheme
@@ -1,0 +1,89 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0700"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8178F9841BB0F87700AD289D"
+               BuildableName = "Bolts.framework"
+               BlueprintName = "Bolts-watchOS"
+               ReferencedContainer = "container:Bolts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8178F9841BB0F87700AD289D"
+            BuildableName = "Bolts.framework"
+            BlueprintName = "Bolts-watchOS"
+            ReferencedContainer = "container:Bolts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8178F9841BB0F87700AD289D"
+            BuildableName = "Bolts.framework"
+            BlueprintName = "Bolts-watchOS"
+            ReferencedContainer = "container:Bolts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "8178F9841BB0F87700AD289D"
+            BuildableName = "Bolts.framework"
+            BlueprintName = "Bolts-watchOS"
+            ReferencedContainer = "container:Bolts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -17,7 +17,7 @@
 #import <Bolts/BFTask.h>
 #import <Bolts/BFTaskCompletionSource.h>
 
-#if __has_include(<Bolts/BFAppLink.h>) && TARGET_OS_IPHONE && !TARGET_OS_TV
+#if __has_include(<Bolts/BFAppLink.h>) && TARGET_OS_IPHONE && !TARGET_OS_WATCH && !TARGET_OS_TV
 #import <Bolts/BFAppLinkNavigation.h>
 #import <Bolts/BFAppLink.h>
 #import <Bolts/BFAppLinkResolving.h>

--- a/Bolts/Resources/watchOS-Info.plist
+++ b/Bolts/Resources/watchOS-Info.plist
@@ -1,0 +1,26 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
+<plist version="1.0">
+<dict>
+	<key>CFBundleDevelopmentRegion</key>
+	<string>en</string>
+	<key>CFBundleExecutable</key>
+	<string>$(EXECUTABLE_NAME)</string>
+	<key>CFBundleIdentifier</key>
+	<string>com.bolts.boltswatch</string>
+	<key>CFBundleInfoDictionaryVersion</key>
+	<string>6.0</string>
+	<key>CFBundleName</key>
+	<string>$(PRODUCT_NAME)</string>
+	<key>CFBundlePackageType</key>
+	<string>FMWK</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.2.2</string>
+	<key>CFBundleSignature</key>
+	<string>????</string>
+	<key>CFBundleVersion</key>
+	<string>1.2.2</string>
+	<key>NSPrincipalClass</key>
+	<string></string>
+</dict>
+</plist>

--- a/Configurations/Bolts-watchOS.xcconfig
+++ b/Configurations/Bolts-watchOS.xcconfig
@@ -1,0 +1,22 @@
+//
+// Copyright (c) 2014, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#include "Shared/Platform/watchOS.xcconfig"
+#include "Shared/Product/Framework.xcconfig"
+
+PRODUCT_NAME = Bolts
+
+MACH_O_TYPE = staticlib
+APPLICATION_EXTENSION_API_ONLY = YES
+
+DEFINES_MODULE = YES
+
+OTHER_LDFLAGS = $(inherited) -ObjC
+
+INFOPLIST_FILE = $(SRCROOT)/Bolts/Resources/watchOS-Info.plist

--- a/Configurations/Shared/Platform/watchOS.xcconfig
+++ b/Configurations/Shared/Platform/watchOS.xcconfig
@@ -1,0 +1,14 @@
+//
+// Copyright (c) 2014, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+SDKROOT = watchos
+WATCHOS_DEPLOYMENT_TARGET = 2.0
+
+CODE_SIGN_IDENTITY =
+CODE_SIGNING_REQUIRED = NO


### PR DESCRIPTION
Added watchOS 2 target for Bolts. Same framework name and everything, but deployment and SDK is set to watchOS 2.
Please note - we are still distributing this as static framework, since we don't want to pollute the device with extra code.

Implements first part of #155 