### PR TITLE
Added nullability annotations to Bolts Tasks.

### DIFF
--- a/Bolts/Common/BFCancellationToken.h
+++ b/Bolts/Common/BFCancellationToken.h
@@ -12,6 +12,8 @@
 
 #import <Bolts/BFCancellationTokenRegistration.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  A block that will be called when a token is cancelled.
  */
@@ -36,3 +38,5 @@ typedef void(^BFCancellationBlock)();
 - (BFCancellationTokenRegistration *)registerCancellationObserverWithBlock:(BFCancellationBlock)block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bolts/Common/BFCancellationTokenRegistration.h
+++ b/Bolts/Common/BFCancellationTokenRegistration.h
@@ -10,6 +10,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  Represents the registration of a cancellation observer with a cancellation token.
  Can be used to unregister the observer at a later time.
@@ -23,3 +25,5 @@
 - (void)dispose;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bolts/Common/BFCancellationTokenSource.h
+++ b/Bolts/Common/BFCancellationTokenSource.h
@@ -10,6 +10,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class BFCancellationToken;
 
 /*!
@@ -54,3 +56,5 @@
 - (void)dispose;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bolts/Common/BFExecutor.h
+++ b/Bolts/Common/BFExecutor.h
@@ -10,6 +10,8 @@
 
 #import <Foundation/Foundation.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  An object that can run a given block.
  */
@@ -56,3 +58,5 @@
 - (void)execute:(void(^)())block;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -13,6 +13,8 @@
 #import <Bolts/BFCancellationToken.h>
 #import <Bolts/BFDefines.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*!
  Error domain used if there was multiple errors on <BFTask taskForCompletionOfAllTasks:>.
  */
@@ -36,13 +38,13 @@ extern NSString *const BFTaskMultipleExceptionsException;
 /*!
  A block that can act as a continuation for a task.
  */
-typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
+typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
 
 /*!
  Creates a task that is already completed with the given result.
  @param result The result for the task.
  */
-+ (instancetype)taskWithResult:(BFGenericType)result;
++ (instancetype)taskWithResult:(nullable BFGenericType)result;
 
 /*!
  Creates a task that is already completed with the given error.
@@ -66,7 +68,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  all of the input tasks have completed.
  @param tasks An `NSArray` of the tasks to use as an input.
  */
-+ (instancetype)taskForCompletionOfAllTasks:(NSArray *)tasks;
++ (instancetype)taskForCompletionOfAllTasks:(nullable NSArray *)tasks;
 
 /*!
  Returns a task that will be completed once all of the input tasks have completed.
@@ -74,7 +76,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  an `NSArray` of all task results in the order they were provided.
  @param tasks An `NSArray` of the tasks to use as an input.
  */
-+ (instancetype)taskForCompletionOfAllTasksWithResults:(NSArray *)tasks;
++ (instancetype)taskForCompletionOfAllTasksWithResults:(nullable NSArray *)tasks;
 
 /*!
  Returns a task that will be completed a certain amount of time in the future.
@@ -90,7 +92,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  @param token The cancellation token (optional).
  */
 + (instancetype)taskWithDelay:(int)millis
-            cancellationToken:(BFCancellationToken *)token;
+            cancellationToken:(nullable BFCancellationToken *)token;
 
 /*!
  Returns a task that will be completed after the given block completes with
@@ -110,17 +112,17 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
 /*!
  The result of a successful task.
  */
-@property (nonatomic, strong, readonly) BFGenericType result;
+@property (nullable, nonatomic, strong, readonly) BFGenericType result;
 
 /*!
  The error of a failed task.
  */
-@property (nonatomic, strong, readonly) NSError *error;
+@property (nullable, nonatomic, strong, readonly) NSError *error;
 
 /*!
  The exception of a failed task.
  */
-@property (nonatomic, strong, readonly) NSException *exception;
+@property (nullable, nonatomic, strong, readonly) NSException *exception;
 
 /*!
  Whether this task has been cancelled.
@@ -163,7 +165,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  this method will not be completed until that task is completed.
  */
 - (instancetype)continueWithBlock:(BFContinuationBlock)block
-                cancellationToken:(BFCancellationToken *)cancellationToken;
+                cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Enqueues the given block to be run once this task is complete.
@@ -188,7 +190,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  */
 - (instancetype)continueWithExecutor:(BFExecutor *)executor
                                block:(BFContinuationBlock)block
-                   cancellationToken:(BFCancellationToken *)cancellationToken;
+                   cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Identical to continueWithBlock:, except that the block is only run
@@ -214,7 +216,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  this method will not be completed until that task is completed.
  */
 - (instancetype)continueWithSuccessBlock:(BFContinuationBlock)block
-                       cancellationToken:(BFCancellationToken *)cancellationToken;
+                       cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Identical to continueWithExecutor:withBlock:, except that the block
@@ -246,7 +248,7 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
  */
 - (instancetype)continueWithExecutor:(BFExecutor *)executor
                         successBlock:(BFContinuationBlock)block
-                   cancellationToken:(BFCancellationToken *)cancellationToken;
+                   cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Waits until this operation is completed.
@@ -257,3 +259,5 @@ typedef id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *task);
 - (void)waitUntilFinished;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bolts/Common/BFTaskCompletionSource.h
+++ b/Bolts/Common/BFTaskCompletionSource.h
@@ -12,6 +12,8 @@
 
 #import <Bolts/BFDefines.h>
 
+NS_ASSUME_NONNULL_BEGIN
+
 @class BFTask BF_GENERIC(BFGenericType);
 
 /*!
@@ -36,7 +38,7 @@
  Attempting to set this for a completed task will raise an exception.
  @param result The result of the task.
  */
-- (void)setResult:(BFGenericType)result;
+- (void)setResult:(nullable BFGenericType)result;
 
 /*!
  Completes the task by setting the error.
@@ -62,7 +64,7 @@
  Sets the result of the task if it wasn't already completed.
  @returns whether the new value was set.
  */
-- (BOOL)trySetResult:(BFGenericType)result;
+- (BOOL)trySetResult:(nullable BFGenericType)result;
 
 /*!
  Sets the error of the task if it wasn't already completed.
@@ -85,3 +87,5 @@
 - (BOOL)trySetCancelled;
 
 @end
+
+NS_ASSUME_NONNULL_END

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -29,6 +29,8 @@
 #import <Bolts/BFWebViewAppLinkResolver.h>
 #endif
 
+NS_ASSUME_NONNULL_BEGIN
+
 /*! @abstract 80175001: There were multiple errors. */
 extern NSInteger const kBFMultipleErrorsError;
 
@@ -41,3 +43,5 @@ extern NSInteger const kBFMultipleErrorsError;
 + (NSString *)version;
 
 @end
+
+NS_ASSUME_NONNULL_END


### PR DESCRIPTION
Closes #161 

This pull request adds nullability annotations to Bolts Tasks.
Few highlights:
- This is somewhat potentially breaking, since there are no more implicitly unwrapped optionals in Swift after this is done
- This will work on any Xcode 6.3.1+ (which is going to be a requirement after this is merged in) (I can make it support versions before, but it will get way more polluted, and not sure on the actual impact)
- For qualifiers - this is still using `__nullable` instead of `_Nullable`, since the latter is available on Xcode 7.0+ only

Everything is split into separate commits for easier review, will squash later.

cc @grantland @hallucinogen