### PR TITLE
Dynamic Library for iOS Carthage Support

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -7,6 +7,44 @@
 	objects = {
 
 /* Begin PBXBuildFile section */
+		1D5D7DA81BE3CE8200FD67C7 /* BFURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6519900A84000BAE3F /* BFURL.m */; };
+		1D5D7DA91BE3CE8200FD67C7 /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
+		1D5D7DAA1BE3CE8200FD67C7 /* BFAppLinkTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6319900A84000BAE3F /* BFAppLinkTarget.m */; };
+		1D5D7DAB1BE3CE8200FD67C7 /* BFAppLinkReturnToRefererView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6019900A84000BAE3F /* BFAppLinkReturnToRefererView.m */; };
+		1D5D7DAC1BE3CE8200FD67C7 /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
+		1D5D7DAD1BE3CE8200FD67C7 /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
+		1D5D7DAE1BE3CE8200FD67C7 /* BFCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA39C911ADE715400DD78CC /* BFCancellationTokenRegistration.m */; };
+		1D5D7DAF1BE3CE8200FD67C7 /* BFCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC21ACF093D00747DD7 /* BFCancellationTokenSource.m */; };
+		1D5D7DB01BE3CE8200FD67C7 /* BFMeasurementEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = B242FAB919A567660097ECAE /* BFMeasurementEvent.m */; };
+		1D5D7DB11BE3CE8200FD67C7 /* BFWebViewAppLinkResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6719900A84000BAE3F /* BFWebViewAppLinkResolver.m */; };
+		1D5D7DB21BE3CE8200FD67C7 /* BFAppLinkNavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5B19900A84000BAE3F /* BFAppLinkNavigation.m */; };
+		1D5D7DB31BE3CE8200FD67C7 /* BFAppLinkReturnToRefererController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5E19900A84000BAE3F /* BFAppLinkReturnToRefererController.m */; };
+		1D5D7DB41BE3CE8200FD67C7 /* BFAppLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5919900A84000BAE3F /* BFAppLink.m */; };
+		1D5D7DB51BE3CE8200FD67C7 /* BFExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA4F19900A84000BAE3F /* BFExecutor.m */; };
+		1D5D7DB61BE3CE8200FD67C7 /* BFCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEBE1ACF08F300747DD7 /* BFCancellationToken.m */; };
+		1D5D7DB81BE3CE8200FD67C7 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
+		1D5D7DBA1BE3CE8200FD67C7 /* BFWebViewAppLinkResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6619900A84000BAE3F /* BFWebViewAppLinkResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DBB1BE3CE8200FD67C7 /* BFCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CA39C901ADE715400DD78CC /* BFCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DBC1BE3CE8200FD67C7 /* BFTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5019900A84000BAE3F /* BFTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DBD1BE3CE8200FD67C7 /* BFAppLinkNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5A19900A84000BAE3F /* BFAppLinkNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DBE1BE3CE8200FD67C7 /* BFAppLinkReturnToRefererView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5F19900A84000BAE3F /* BFAppLinkReturnToRefererView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DBF1BE3CE8200FD67C7 /* BFCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEC11ACF093D00747DD7 /* BFCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC01BE3CE8200FD67C7 /* BFExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA4E19900A84000BAE3F /* BFExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC11BE3CE8200FD67C7 /* BFAppLinkTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6219900A84000BAE3F /* BFAppLinkTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC21BE3CE8200FD67C7 /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC31BE3CE8200FD67C7 /* BFURL_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FABA19A567660097ECAE /* BFURL_Internal.h */; };
+		1D5D7DC41BE3CE8200FD67C7 /* BFAppLinkResolving.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5C19900A84000BAE3F /* BFAppLinkResolving.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC51BE3CE8200FD67C7 /* BFAppLinkReturnToRefererView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6119900A84000BAE3F /* BFAppLinkReturnToRefererView_Internal.h */; };
+		1D5D7DC61BE3CE8200FD67C7 /* BFURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6419900A84000BAE3F /* BFURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC71BE3CE8200FD67C7 /* BFTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5219900A84000BAE3F /* BFTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC81BE3CE8200FD67C7 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DC91BE3CE8200FD67C7 /* BFMeasurementEvent_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAC019A599CD0097ECAE /* BFMeasurementEvent_Internal.h */; };
+		1D5D7DCA1BE3CE8200FD67C7 /* BFMeasurementEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAB819A567660097ECAE /* BFMeasurementEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DCB1BE3CE8200FD67C7 /* BFAppLink_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAB719A567660097ECAE /* BFAppLink_Internal.h */; };
+		1D5D7DCC1BE3CE8200FD67C7 /* Bolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5419900A84000BAE3F /* Bolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DCD1BE3CE8200FD67C7 /* BFCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEBD1ACF08F300747DD7 /* BFCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DCE1BE3CE8200FD67C7 /* BFAppLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5819900A84000BAE3F /* BFAppLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		1D5D7DCF1BE3CE8200FD67C7 /* BFAppLinkReturnToRefererController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5D19900A84000BAE3F /* BFAppLinkReturnToRefererController.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		1E9BF8DC18EA0CAD00514B1E /* test.html in Resources */ = {isa = PBXBuildFile; fileRef = 1E9BF8DB18EA0CAD00514B1E /* test.html */; };
 		1EC3016118CDAA8400D06D07 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
 		1EC3016318CDAA8400D06D07 /* CoreGraphics.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 1EC3016218CDAA8400D06D07 /* CoreGraphics.framework */; };
@@ -155,6 +193,8 @@
 /* End PBXContainerItemProxy section */
 
 /* Begin PBXFileReference section */
+		1D5D7DA41BE3CE7C00FD67C7 /* Bolts-iOS-Dynamic.xcconfig */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.xcconfig; path = "Bolts-iOS-Dynamic.xcconfig"; sourceTree = "<group>"; };
+		1D5D7DD31BE3CE8200FD67C7 /* Bolts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bolts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		1E9BF8DB18EA0CAD00514B1E /* test.html */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.html; path = test.html; sourceTree = "<group>"; };
 		1EC3016018CDAA8400D06D07 /* BoltsTestUI.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = BoltsTestUI.app; sourceTree = BUILT_PRODUCTS_DIR; };
 		1EC3016218CDAA8400D06D07 /* CoreGraphics.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = CoreGraphics.framework; path = System/Library/Frameworks/CoreGraphics.framework; sourceTree = SDKROOT; };
@@ -248,6 +288,14 @@
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
+		1D5D7DB71BE3CE8200FD67C7 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D5D7DB81BE3CE8200FD67C7 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1EC3015D18CDAA8300D06D07 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
@@ -394,6 +442,7 @@
 			isa = PBXGroup;
 			children = (
 				81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */,
+				1D5D7DA41BE3CE7C00FD67C7 /* Bolts-iOS-Dynamic.xcconfig */,
 				81279F731B9A3F06006696C2 /* Bolts-OSX.xcconfig */,
 				F5AFCA151BA752AF0076E927 /* Bolts-tvOS.xcconfig */,
 				8178F9831BB0F86000AD289D /* Bolts-watchOS.xcconfig */,
@@ -496,6 +545,7 @@
 				8178F99C1BB0F87700AD289D /* Bolts.framework */,
 				81ED94291BE147CF00795F05 /* Bolts.framework */,
 				81ED946E1BE14B5200795F05 /* Bolts.framework */,
+				1D5D7DD31BE3CE8200FD67C7 /* Bolts.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -538,6 +588,35 @@
 /* End PBXGroup section */
 
 /* Begin PBXHeadersBuildPhase section */
+		1D5D7DB91BE3CE8200FD67C7 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D5D7DBA1BE3CE8200FD67C7 /* BFWebViewAppLinkResolver.h in Headers */,
+				1D5D7DBB1BE3CE8200FD67C7 /* BFCancellationTokenRegistration.h in Headers */,
+				1D5D7DBC1BE3CE8200FD67C7 /* BFTask.h in Headers */,
+				1D5D7DBD1BE3CE8200FD67C7 /* BFAppLinkNavigation.h in Headers */,
+				1D5D7DBE1BE3CE8200FD67C7 /* BFAppLinkReturnToRefererView.h in Headers */,
+				1D5D7DBF1BE3CE8200FD67C7 /* BFCancellationTokenSource.h in Headers */,
+				1D5D7DC01BE3CE8200FD67C7 /* BFExecutor.h in Headers */,
+				1D5D7DC11BE3CE8200FD67C7 /* BFAppLinkTarget.h in Headers */,
+				1D5D7DC21BE3CE8200FD67C7 /* BFDefines.h in Headers */,
+				1D5D7DC31BE3CE8200FD67C7 /* BFURL_Internal.h in Headers */,
+				1D5D7DC41BE3CE8200FD67C7 /* BFAppLinkResolving.h in Headers */,
+				1D5D7DC51BE3CE8200FD67C7 /* BFAppLinkReturnToRefererView_Internal.h in Headers */,
+				1D5D7DC61BE3CE8200FD67C7 /* BFURL.h in Headers */,
+				1D5D7DC71BE3CE8200FD67C7 /* BFTaskCompletionSource.h in Headers */,
+				1D5D7DC81BE3CE8200FD67C7 /* BoltsVersion.h in Headers */,
+				1D5D7DC91BE3CE8200FD67C7 /* BFMeasurementEvent_Internal.h in Headers */,
+				1D5D7DCA1BE3CE8200FD67C7 /* BFMeasurementEvent.h in Headers */,
+				1D5D7DCB1BE3CE8200FD67C7 /* BFAppLink_Internal.h in Headers */,
+				1D5D7DCC1BE3CE8200FD67C7 /* Bolts.h in Headers */,
+				1D5D7DCD1BE3CE8200FD67C7 /* BFCancellationToken.h in Headers */,
+				1D5D7DCE1BE3CE8200FD67C7 /* BFAppLink.h in Headers */,
+				1D5D7DCF1BE3CE8200FD67C7 /* BFAppLinkReturnToRefererController.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8178F98F1BB0F87700AD289D /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -618,6 +697,23 @@
 /* End PBXHeadersBuildPhase section */
 
 /* Begin PBXNativeTarget section */
+		1D5D7DA61BE3CE8200FD67C7 /* Bolts-iOS-Dynamic */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 1D5D7DD01BE3CE8200FD67C7 /* Build configuration list for PBXNativeTarget "Bolts-iOS-Dynamic" */;
+			buildPhases = (
+				1D5D7DA71BE3CE8200FD67C7 /* Sources */,
+				1D5D7DB71BE3CE8200FD67C7 /* Frameworks */,
+				1D5D7DB91BE3CE8200FD67C7 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Bolts-iOS-Dynamic";
+			productName = Bolts;
+			productReference = 1D5D7DD31BE3CE8200FD67C7 /* Bolts.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		1EC3015F18CDAA8300D06D07 /* BoltsTestUI */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 1EC3018E18CDAA8400D06D07 /* Build configuration list for PBXNativeTarget "BoltsTestUI" */;
@@ -785,6 +881,7 @@
 			projectRoot = "";
 			targets = (
 				81ED94111BE147CF00795F05 /* Bolts-iOS */,
+				1D5D7DA61BE3CE8200FD67C7 /* Bolts-iOS-Dynamic */,
 				8EDDA62817E17DDC00655F8A /* Bolts-OSX */,
 				F5AFC9EA1BA752750076E927 /* Bolts-tvOS */,
 				8178F9841BB0F87700AD289D /* Bolts-watchOS */,
@@ -831,6 +928,28 @@
 /* End PBXResourcesBuildPhase section */
 
 /* Begin PBXSourcesBuildPhase section */
+		1D5D7DA71BE3CE8200FD67C7 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				1D5D7DA81BE3CE8200FD67C7 /* BFURL.m in Sources */,
+				1D5D7DA91BE3CE8200FD67C7 /* BFTaskCompletionSource.m in Sources */,
+				1D5D7DAA1BE3CE8200FD67C7 /* BFAppLinkTarget.m in Sources */,
+				1D5D7DAB1BE3CE8200FD67C7 /* BFAppLinkReturnToRefererView.m in Sources */,
+				1D5D7DAC1BE3CE8200FD67C7 /* BFTask.m in Sources */,
+				1D5D7DAD1BE3CE8200FD67C7 /* Bolts.m in Sources */,
+				1D5D7DAE1BE3CE8200FD67C7 /* BFCancellationTokenRegistration.m in Sources */,
+				1D5D7DAF1BE3CE8200FD67C7 /* BFCancellationTokenSource.m in Sources */,
+				1D5D7DB01BE3CE8200FD67C7 /* BFMeasurementEvent.m in Sources */,
+				1D5D7DB11BE3CE8200FD67C7 /* BFWebViewAppLinkResolver.m in Sources */,
+				1D5D7DB21BE3CE8200FD67C7 /* BFAppLinkNavigation.m in Sources */,
+				1D5D7DB31BE3CE8200FD67C7 /* BFAppLinkReturnToRefererController.m in Sources */,
+				1D5D7DB41BE3CE8200FD67C7 /* BFAppLink.m in Sources */,
+				1D5D7DB51BE3CE8200FD67C7 /* BFExecutor.m in Sources */,
+				1D5D7DB61BE3CE8200FD67C7 /* BFCancellationToken.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		1EC3015C18CDAA8300D06D07 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -992,6 +1111,20 @@
 /* End PBXVariantGroup section */
 
 /* Begin XCBuildConfiguration section */
+		1D5D7DD11BE3CE8200FD67C7 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D5D7DA41BE3CE7C00FD67C7 /* Bolts-iOS-Dynamic.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		1D5D7DD21BE3CE8200FD67C7 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 1D5D7DA41BE3CE7C00FD67C7 /* Bolts-iOS-Dynamic.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		1EC3018618CDAA8400D06D07 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			buildSettings = {
@@ -1160,6 +1293,15 @@
 /* End XCBuildConfiguration section */
 
 /* Begin XCConfigurationList section */
+		1D5D7DD01BE3CE8200FD67C7 /* Build configuration list for PBXNativeTarget "Bolts-iOS-Dynamic" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				1D5D7DD11BE3CE8200FD67C7 /* Debug */,
+				1D5D7DD21BE3CE8200FD67C7 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		1EC3018E18CDAA8400D06D07 /* Build configuration list for PBXNativeTarget "BoltsTestUI" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (

--- a/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-iOS-Dynamic.xcscheme
+++ b/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-iOS-Dynamic.xcscheme
@@ -1,0 +1,80 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<Scheme
+   LastUpgradeVersion = "0710"
+   version = "1.3">
+   <BuildAction
+      parallelizeBuildables = "YES"
+      buildImplicitDependencies = "YES">
+      <BuildActionEntries>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "YES"
+            buildForProfiling = "YES"
+            buildForArchiving = "YES"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "1D5D7DA61BE3CE8200FD67C7"
+               BuildableName = "Bolts.framework"
+               BlueprintName = "Bolts-iOS-Dynamic"
+               ReferencedContainer = "container:Bolts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+      </BuildActionEntries>
+   </BuildAction>
+   <TestAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      shouldUseLaunchSchemeArgsEnv = "YES">
+      <Testables>
+      </Testables>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </TestAction>
+   <LaunchAction
+      buildConfiguration = "Debug"
+      selectedDebuggerIdentifier = "Xcode.DebuggerFoundation.Debugger.LLDB"
+      selectedLauncherIdentifier = "Xcode.DebuggerFoundation.Launcher.LLDB"
+      launchStyle = "0"
+      useCustomWorkingDirectory = "NO"
+      ignoresPersistentStateOnLaunch = "NO"
+      debugDocumentVersioning = "YES"
+      debugServiceExtension = "internal"
+      allowLocationSimulation = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D5D7DA61BE3CE8200FD67C7"
+            BuildableName = "Bolts.framework"
+            BlueprintName = "Bolts-iOS-Dynamic"
+            ReferencedContainer = "container:Bolts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+      <AdditionalOptions>
+      </AdditionalOptions>
+   </LaunchAction>
+   <ProfileAction
+      buildConfiguration = "Release"
+      shouldUseLaunchSchemeArgsEnv = "YES"
+      savedToolIdentifier = ""
+      useCustomWorkingDirectory = "NO"
+      debugDocumentVersioning = "YES">
+      <MacroExpansion>
+         <BuildableReference
+            BuildableIdentifier = "primary"
+            BlueprintIdentifier = "1D5D7DA61BE3CE8200FD67C7"
+            BuildableName = "Bolts.framework"
+            BlueprintName = "Bolts-iOS-Dynamic"
+            ReferencedContainer = "container:Bolts.xcodeproj">
+         </BuildableReference>
+      </MacroExpansion>
+   </ProfileAction>
+   <AnalyzeAction
+      buildConfiguration = "Debug">
+   </AnalyzeAction>
+   <ArchiveAction
+      buildConfiguration = "Release"
+      revealArchiveInOrganizer = "YES">
+   </ArchiveAction>
+</Scheme>

--- a/Configurations/Bolts-iOS-Dynamic.xcconfig
+++ b/Configurations/Bolts-iOS-Dynamic.xcconfig
@@ -1,0 +1,25 @@
+//
+// Copyright (c) 2014, Facebook, Inc.
+// All rights reserved.
+//
+// This source code is licensed under the BSD-style license found in the
+// LICENSE file in the root directory of this source tree. An additional grant
+// of patent rights can be found in the PATENTS file in the same directory.
+//
+
+#include "Shared/Platform/iOS.xcconfig"
+#include "Shared/Product/Framework.xcconfig"
+
+PRODUCT_NAME = Bolts
+IPHONEOS_DEPLOYMENT_TARGET = 8.0
+
+MACH_O_TYPE = mh_dylib
+
+DEFINES_MODULE = YES
+MODULEMAP_FILE = $(SRCROOT)/Bolts/Resources/iOS.modulemap
+
+OTHER_CFLAGS[sdk=iphoneos9.*] = $(inherited) -fembed-bitcode
+
+OTHER_LDFLAGS = $(inherited) -ObjC -framework CoreGraphics -framework UIKit
+
+INFOPLIST_FILE = $(SRCROOT)/Bolts/Resources/iOS-Info.plist


### PR DESCRIPTION
Trying to address issue #152, this build I believe will support Carthage. The issue is that Bolts is currently a static library, whereas Carthage only supports dynamic libraries (hence why the Mac build works). I know there can be backwards compatibility issues so I've added a new target that builds dynamically. I'd really like this to get moved into production so that Facebook could support Carthage out of the box. Let me know if anything needs to be changed.