### PR TITLE
Fix all new warnings, use modular imports in tests.

### DIFF
--- a/Bolts/Common/BFCancellationToken.m
+++ b/Bolts/Common/BFCancellationToken.m
@@ -33,10 +33,12 @@
 #pragma mark - Initializer
 
 - (instancetype)init {
-    if (self = [super init]) {
-        _registrations = [NSMutableArray array];
-        _lock = [NSObject new];
-    }
+    self = [super init];
+    if (!self) return nil;
+
+    _registrations = [NSMutableArray array];
+    _lock = [NSObject new];
+
     return self;
 }
 

--- a/Bolts/Common/BFCancellationTokenRegistration.m
+++ b/Bolts/Common/BFCancellationTokenRegistration.m
@@ -37,9 +37,11 @@
 }
 
 - (instancetype)init {
-    if (self = [super init]) {
-        _lock = [NSObject new];
-    }
+    self = [super init];
+    if (!self) return nil;
+
+    _lock = [NSObject new];
+    
     return self;
 }
 

--- a/Bolts/Common/BFExecutor.m
+++ b/Bolts/Common/BFExecutor.m
@@ -97,9 +97,11 @@
 #pragma mark - Initializer
 
 - (instancetype)initWithBlock:(void(^)(void(^block)()))block {
-    if (self = [super init]) {
-        _block = block;
-    }
+    self = [super init];
+    if (!self) return nil;
+
+    _block = block;
+
     return self;
 }
 

--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -43,11 +43,13 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 #pragma mark - Initializer
 
 - (instancetype)init {
-    if (self = [super init]) {
-        _lock = [[NSObject alloc] init];
-        _condition = [[NSCondition alloc] init];
-        _callbacks = [NSMutableArray array];
-    }
+    self = [super init];
+    if (!self) return nil;
+
+    _lock = [[NSObject alloc] init];
+    _condition = [[NSCondition alloc] init];
+    _callbacks = [NSMutableArray array];
+
     return self;
 }
 

--- a/Bolts/Common/BFTaskCompletionSource.m
+++ b/Bolts/Common/BFTaskCompletionSource.m
@@ -40,9 +40,11 @@
 }
 
 - (instancetype)init {
-    if (self = [super init]) {
-        _task = [[BFTask alloc] init];
-    }
+    self = [super init];
+    if (!self) return nil;
+
+    _task = [[BFTask alloc] init];
+
     return self;
 }
 

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -18,8 +18,8 @@
 #import <Bolts/BFTaskCompletionSource.h>
 
 #if __has_include(<Bolts/BFAppLink.h>) && TARGET_OS_IPHONE && !TARGET_OS_WATCH && !TARGET_OS_TV
-#import <Bolts/BFAppLinkNavigation.h>
 #import <Bolts/BFAppLink.h>
+#import <Bolts/BFAppLinkNavigation.h>
 #import <Bolts/BFAppLinkResolving.h>
 #import <Bolts/BFAppLinkReturnToRefererController.h>
 #import <Bolts/BFAppLinkReturnToRefererView.h>

--- a/Bolts/iOS/BFAppLinkNavigation.m
+++ b/Bolts/iOS/BFAppLinkNavigation.m
@@ -198,7 +198,7 @@ static id<BFAppLinkResolving> defaultResolver;
     }
 }
 
-+ (BFTask *)resolveAppLinkInBackground:(NSURL *)destination resolver:(id)resolver {
++ (BFTask *)resolveAppLinkInBackground:(NSURL *)destination resolver:(id<BFAppLinkResolving>)resolver {
     return [resolver appLinkFromURLInBackground:destination];
 }
 

--- a/Bolts/iOS/BFAppLink_Internal.h
+++ b/Bolts/iOS/BFAppLink_Internal.h
@@ -10,6 +10,15 @@
 
 #import <Bolts/BFAppLink.h>
 
+FOUNDATION_EXPORT NSString *const BFAppLinkDataParameterName;
+FOUNDATION_EXPORT NSString *const BFAppLinkTargetKeyName;
+FOUNDATION_EXPORT NSString *const BFAppLinkUserAgentKeyName;
+FOUNDATION_EXPORT NSString *const BFAppLinkExtrasKeyName;
+FOUNDATION_EXPORT NSString *const BFAppLinkVersionKeyName;
+FOUNDATION_EXPORT NSString *const BFAppLinkRefererAppLink;
+FOUNDATION_EXPORT NSString *const BFAppLinkRefererAppName;
+FOUNDATION_EXPORT NSString *const BFAppLinkRefererUrl;
+
 @interface BFAppLink (Internal)
 
 + (instancetype)appLinkWithSourceURL:(NSURL *)sourceURL

--- a/Bolts/iOS/BFWebViewAppLinkResolver.m
+++ b/Bolts/iOS/BFWebViewAppLinkResolver.m
@@ -246,6 +246,7 @@ static NSString *const BFWebViewAppLinkResolverShouldFallbackKey = @"should_fall
             platformData = @[ appLinkDict[BFWebViewAppLinkResolverIPhoneKey] ?: @{},
                               appLinkDict[BFWebViewAppLinkResolverIOSKey] ?: @{} ];
             break;
+        case UIUserInterfaceIdiomUnspecified:
         default:
             // Future-proofing. Other User Interface idioms should only hit ios.
             platformData = @[ appLinkDict[BFWebViewAppLinkResolverIOSKey] ?: @{} ];

--- a/BoltsTests/AppLinkReturnToRefererViewTests.m
+++ b/BoltsTests/AppLinkReturnToRefererViewTests.m
@@ -8,10 +8,9 @@
  *
  */
 
-#import <XCTest/XCTest.h>
+@import XCTest;
 
-#import "BFAppLinkReturnToRefererView.h"
-#import "BFURL.h"
+#import <Bolts/Bolts.h>
 
 static NSString *const BFURLWithRefererData = @"bolts://?foo=bar&al_applink_data=%7B%22a%22%3A%22b%22%2C%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22http%3A%5C%2F%5C%2Fwww.example.com%5C%2Fpath%3Fbaz%3Dbat%22%2C%22referer_app_link%22%3A%7B%22app_name%22%3A%22Facebook%22%2C%22url%22%3A%22fb%3A%5C%2F%5C%2Fsomething%5C%2F%22%7D%7D";
 static NSString *const BFURLWithRefererUrlNoName = @"bolts://?foo=bar&al_applink_data=%7B%22a%22%3A%22b%22%2C%22user_agent%22%3A%22Bolts%20iOS%201.0.0%22%2C%22target_url%22%3A%22http%3A%5C%2F%5C%2Fwww.example.com%5C%2Fpath%3Fbaz%3Dbat%22%2C%22referer_app_link%22%3A%7B%22url%22%3A%22fb%3A%5C%2F%5C%2Fsomething%5C%2F%22%7D%7D";

--- a/BoltsTests/AppLinkTests.m
+++ b/BoltsTests/AppLinkTests.m
@@ -6,15 +6,13 @@
 //  Copyright (c) 2014 Parse Inc. All rights reserved.
 //
 
-#import <XCTest/XCTest.h>
-#import <UIKit/UIKit.h>
-#import <objc/runtime.h>
-#import <objc/message.h>
+@import XCTest;
+@import UIKit;
+@import ObjectiveC.runtime;
 
-#import "Bolts.h"
-#import "BFWebViewAppLinkResolver.h"
+#import <Bolts/Bolts.h>
 
-NSMutableArray *openedUrls = nil;
+static NSMutableArray *openedUrls;
 
 @interface AppLinkTests : XCTestCase
 
@@ -463,6 +461,7 @@ NSMutableArray *openedUrls = nil;
         case UIUserInterfaceIdiomPad:
             XCTAssertEqualObjects(@"bolts2://ipad", target.URL.absoluteString);
             break;
+        case UIUserInterfaceIdiomUnspecified:
         default:
             break;
     }
@@ -728,6 +727,7 @@ NSMutableArray *openedUrls = nil;
         case UIUserInterfaceIdiomPad:
             XCTAssertEqualObjects(@"bolts2://ipad", target.URL.absoluteString);
             break;
+        case UIUserInterfaceIdiomUnspecified:
         default:
             break;
     }

--- a/BoltsTests/BoltsTests.m
+++ b/BoltsTests/BoltsTests.m
@@ -8,9 +8,9 @@
  *
  */
 
-#import <XCTest/XCTest.h>
+@import XCTest;
 
-#import "Bolts.h"
+#import <Bolts/Bolts.h>
 
 @interface BoltsTests : XCTestCase
 @end

--- a/BoltsTests/CancellationTests.m
+++ b/BoltsTests/CancellationTests.m
@@ -8,9 +8,9 @@
  *
  */
 
-#import <XCTest/XCTest.h>
+@import XCTest;
 
-#import "Bolts.h"
+#import <Bolts/Bolts.h>
 
 @interface CancellationTests : XCTestCase
 @end

--- a/BoltsTests/ExecutorTests.m
+++ b/BoltsTests/ExecutorTests.m
@@ -8,9 +8,9 @@
  *
  */
 
-#import <XCTest/XCTest.h>
+@import XCTest;
 
-#import "Bolts.h"
+#import <Bolts/Bolts.h>
 
 @interface ExecutorTests : XCTestCase
 

--- a/BoltsTests/TaskTests.m
+++ b/BoltsTests/TaskTests.m
@@ -8,9 +8,9 @@
  *
  */
 
-#import <XCTest/XCTest.h>
+@import XCTest;
 
-#import "Bolts.h"
+#import <Bolts/Bolts.h>
 
 @interface TaskTests : XCTestCase
 @end


### PR DESCRIPTION
New warnings arouse due to usage of `xctoolchain` - fix them, as well as use modular imports in all tests.