### PR TITLE
Fixed #imports to properly support Xcode 7.1

### DIFF
--- a/Bolts/Common/BFCancellationToken.h
+++ b/Bolts/Common/BFCancellationToken.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFCancellationTokenRegistration.h>
+#import "BFCancellationTokenRegistration.h"
 
 /*!
  A block that will be called when a token is cancelled.

--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -10,8 +10,8 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFCancellationToken.h>
-#import <Bolts/BFDefines.h>
+#import "BFCancellationToken.h"
+#import "BFDefines.h"
 
 /*!
  Error domain used if there was multiple errors on <BFTask taskForCompletionOfAllTasks:>.

--- a/Bolts/Common/BFTaskCompletionSource.h
+++ b/Bolts/Common/BFTaskCompletionSource.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFDefines.h>
+#import "BFDefines.h"
 
 @class BFTask BF_GENERIC(BFGenericType);
 

--- a/Bolts/Common/Bolts.h
+++ b/Bolts/Common/Bolts.h
@@ -8,25 +8,25 @@
  *
  */
 
-#import <Bolts/BoltsVersion.h>
-#import <Bolts/BFCancellationToken.h>
-#import <Bolts/BFCancellationTokenRegistration.h>
-#import <Bolts/BFCancellationTokenSource.h>
-#import <Bolts/BFDefines.h>
-#import <Bolts/BFExecutor.h>
-#import <Bolts/BFTask.h>
-#import <Bolts/BFTaskCompletionSource.h>
+#import "BoltsVersion.h"
+#import "BFCancellationToken.h"
+#import "BFCancellationTokenRegistration.h"
+#import "BFCancellationTokenSource.h"
+#import "BFDefines.h"
+#import "BFExecutor.h"
+#import "BFTask.h"
+#import "BFTaskCompletionSource.h"
 
 #if __has_include(<Bolts/BFAppLink.h>) && TARGET_OS_IPHONE && !TARGET_OS_WATCH && !TARGET_OS_TV
-#import <Bolts/BFAppLink.h>
-#import <Bolts/BFAppLinkNavigation.h>
-#import <Bolts/BFAppLinkResolving.h>
-#import <Bolts/BFAppLinkReturnToRefererController.h>
-#import <Bolts/BFAppLinkReturnToRefererView.h>
-#import <Bolts/BFAppLinkTarget.h>
-#import <Bolts/BFMeasurementEvent.h>
-#import <Bolts/BFURL.h>
-#import <Bolts/BFWebViewAppLinkResolver.h>
+#import "BFAppLink.h"
+#import "BFAppLinkNavigation.h"
+#import "BFAppLinkResolving.h"
+#import "BFAppLinkReturnToRefererController.h"
+#import "BFAppLinkReturnToRefererView.h"
+#import "BFAppLinkTarget.h"
+#import "BFMeasurementEvent.h"
+#import "BFURL.h"
+#import "BFWebViewAppLinkResolver.h"
 #endif
 
 /*! @abstract 80175001: There were multiple errors. */

--- a/Bolts/iOS/BFAppLinkNavigation.h
+++ b/Bolts/iOS/BFAppLinkNavigation.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFAppLink.h>
+#import "BFAppLink.h"
 
 /*!
  The result of calling navigate on a BFAppLinkNavigation

--- a/Bolts/iOS/BFAppLinkReturnToRefererController.h
+++ b/Bolts/iOS/BFAppLinkReturnToRefererController.h
@@ -11,7 +11,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import <Bolts/BFAppLinkReturnToRefererView.h>
+#import "BFAppLinkReturnToRefererView.h"
 
 @class BFAppLink;
 @class BFAppLinkReturnToRefererController;

--- a/Bolts/iOS/BFAppLinkReturnToRefererView.h
+++ b/Bolts/iOS/BFAppLinkReturnToRefererView.h
@@ -11,7 +11,7 @@
 #import <Foundation/Foundation.h>
 #import <UIKit/UIKit.h>
 
-#import <Bolts/BFAppLinkNavigation.h>
+#import "BFAppLinkNavigation.h"
 
 @class BFAppLinkReturnToRefererView;
 @class BFURL;

--- a/Bolts/iOS/BFAppLinkReturnToRefererView_Internal.h
+++ b/Bolts/iOS/BFAppLinkReturnToRefererView_Internal.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <Bolts/BFAppLinkReturnToRefererView.h>
+#import "BFAppLinkReturnToRefererView.h"
 
 @interface BFAppLinkReturnToRefererView (Internal)
 

--- a/Bolts/iOS/BFAppLink_Internal.h
+++ b/Bolts/iOS/BFAppLink_Internal.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <Bolts/BFAppLink.h>
+#import "BFAppLink.h"
 
 FOUNDATION_EXPORT NSString *const BFAppLinkDataParameterName;
 FOUNDATION_EXPORT NSString *const BFAppLinkTargetKeyName;

--- a/Bolts/iOS/BFMeasurementEvent_Internal.h
+++ b/Bolts/iOS/BFMeasurementEvent_Internal.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <Bolts/BFMeasurementEvent.h>
+#import "BFMeasurementEvent.h"
 /*!
  Provides methods for posting notifications from the Bolts framework
  */

--- a/Bolts/iOS/BFURL_Internal.h
+++ b/Bolts/iOS/BFURL_Internal.h
@@ -8,7 +8,7 @@
  *
  */
 
-#import <Bolts/BFURL.h>
+#import "BFURL.h"
 
 @interface BFURL (Internal)
 + (BFURL *)URLForRenderBackToReferrerBarURL:(NSURL *)url;

--- a/Bolts/iOS/BFWebViewAppLinkResolver.h
+++ b/Bolts/iOS/BFWebViewAppLinkResolver.h
@@ -10,7 +10,7 @@
 
 #import <Foundation/Foundation.h>
 
-#import <Bolts/BFAppLinkResolving.h>
+#import "BFAppLinkResolving.h"
 
 /*!
  A reference implementation for an App Link resolver that uses a hidden UIWebView


### PR DESCRIPTION
A framework's header files can no longer import other own header files using angular import syntax (`#import <Bolts/…>`) as of Xcode 7.1. That leads to a lot errors when importing (not compiling) this framework.

Example:
```
Pods/Bolts/Bolts/Common/BFCancellationToken.h:13:9: error: include of non-modular header inside framework module 'Bolts.BFCancellationToken' [-Werror,-Wnon-modular-include-in-framework-module]
#import <Bolts/BFCancellationTokenRegistration.h>
```

Properly using `#import "XYZ.h"` instead of `#import <Bolts/XYZ.h>` fixes this issue.