### PR TITLE
Improve performance of task constructors.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -56,27 +56,27 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 #pragma mark - Task Class methods
 
 + (instancetype)taskWithResult:(id)result {
-    BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
-    tcs.result = result;
-    return tcs.task;
+    BFTask *task = [[self alloc] init];
+    [task trySetResult:result];
+    return task;
 }
 
 + (instancetype)taskWithError:(NSError *)error {
-    BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
-    tcs.error = error;
-    return tcs.task;
+    BFTask *task = [[self alloc] init];
+    [task trySetError:error];
+    return task;
 }
 
 + (instancetype)taskWithException:(NSException *)exception {
-    BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
-    tcs.exception = exception;
-    return tcs.task;
+    BFTask *task = [[self alloc] init];
+    [task trySetException:exception];
+    return task;
 }
 
 + (instancetype)cancelledTask {
-    BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
-    [tcs cancel];
-    return tcs.task;
+    BFTask *task = [[self alloc] init];
+    [task trySetCancelled];
+    return task;
 }
 
 + (instancetype)taskForCompletionOfAllTasks:(NSArray *)tasks {


### PR DESCRIPTION
The previous flow creates a task completion source and a task everytime, this flow has the following benefits:
- Creating 1 object less on construction of every task
- Properly follows `instancetype` return type, as it will always call into `self.init()`