### PR TITLE
Fixed potential memory corruption on accessing a description of a task.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -451,11 +451,13 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
     BOOL completed;
     BOOL cancelled;
     BOOL faulted;
+    NSString *resultDescription = nil;
 
     @synchronized(self.lock) {
         completed = self.completed;
         cancelled = self.cancelled;
         faulted = self.faulted;
+        resultDescription = completed ? [NSString stringWithFormat:@" result = %@", self.result] : @"";
     }
 
     // Description string includes status information and, if available, the
@@ -466,7 +468,7 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
             completed ? @"YES" : @"NO",
             cancelled ? @"YES" : @"NO",
             faulted ? @"YES" : @"NO",
-            completed ? [NSString stringWithFormat:@" result:%@", _result] : @""];
+            resultDescription];
 }
 
 @end


### PR DESCRIPTION
Accessing `_result` directly is not thread-safe, and it might have changed since the moment of invocation to the moment when the method returns.
This way we guarantee that `completed` and `result` are consistent, as well as accessing `result` here is fully thread-safe.