### PR TITLE
Fix warning in BFWebViewAppLinkResolver.m.

### DIFF
--- a/Bolts/iOS/BFWebViewAppLinkResolver.m
+++ b/Bolts/iOS/BFWebViewAppLinkResolver.m
@@ -246,6 +246,9 @@ static NSString *const BFWebViewAppLinkResolverShouldFallbackKey = @"should_fall
             platformData = @[ appLinkDict[BFWebViewAppLinkResolverIPhoneKey] ?: @{},
                               appLinkDict[BFWebViewAppLinkResolverIOSKey] ?: @{} ];
             break;
+#ifdef __TVOS_9_0
+        case UIUserInterfaceIdiomTV:
+#endif
         case UIUserInterfaceIdiomUnspecified:
         default:
             // Future-proofing. Other User Interface idioms should only hit ios.

--- a/BoltsTests/AppLinkTests.m
+++ b/BoltsTests/AppLinkTests.m
@@ -461,6 +461,9 @@ static NSMutableArray *openedUrls;
         case UIUserInterfaceIdiomPad:
             XCTAssertEqualObjects(@"bolts2://ipad", target.URL.absoluteString);
             break;
+#ifdef __TVOS_9_0
+        case UIUserInterfaceIdiomTV:
+#endif
         case UIUserInterfaceIdiomUnspecified:
         default:
             break;
@@ -727,6 +730,9 @@ static NSMutableArray *openedUrls;
         case UIUserInterfaceIdiomPad:
             XCTAssertEqualObjects(@"bolts2://ipad", target.URL.absoluteString);
             break;
+#ifdef __TVOS_9_0
+        case UIUserInterfaceIdiomTV:
+#endif
         case UIUserInterfaceIdiomUnspecified:
         default:
             break;


### PR DESCRIPTION
This interface idiom is the new one coming from TVOS.
The usage of ifdef here is essential, due to the fact that it might not be available.