### PR TITLE
Simplify settings properties on a Task from TaskCompletionSource.

### DIFF
--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -185,13 +185,6 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
     }
 }
 
-- (void)setResult:(id)result {
-    if (![self trySetResult:result]) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"Cannot set the result on a completed task."];
-    }
-}
-
 - (BOOL)trySetResult:(id)result {
     @synchronized(self.lock) {
         if (self.completed) {
@@ -207,13 +200,6 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 - (NSError *)error {
     @synchronized(self.lock) {
         return _error;
-    }
-}
-
-- (void)setError:(NSError *)error {
-    if (![self trySetError:error]) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"Cannot set the error on a completed task."];
     }
 }
 
@@ -233,13 +219,6 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 - (NSException *)exception {
     @synchronized(self.lock) {
         return _exception;
-    }
-}
-
-- (void)setException:(NSException *)exception {
-    if (![self trySetException:exception]) {
-        [NSException raise:NSInternalInconsistencyException
-                    format:@"Cannot set the exception on a completed task."];
     }
 }
 
@@ -265,15 +244,6 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 - (BOOL)isFaulted {
     @synchronized(self.lock) {
         return _faulted;
-    }
-}
-
-- (void)cancel {
-    @synchronized(self.lock) {
-        if (![self trySetCancelled]) {
-            [NSException raise:NSInternalInconsistencyException
-                        format:@"Cannot cancel a completed task."];
-        }
     }
 }
 

--- a/Bolts/Common/BFTaskCompletionSource.m
+++ b/Bolts/Common/BFTaskCompletionSource.m
@@ -20,10 +20,6 @@
 
 @interface BFTask (BFTaskCompletionSource)
 
-- (void)setResult:(id)result;
-- (void)setError:(NSError *)error;
-- (void)setException:(NSException *)exception;
-- (void)cancel;
 - (BOOL)trySetResult:(id)result;
 - (BOOL)trySetError:(NSError *)error;
 - (BOOL)trySetException:(NSException *)exception;
@@ -51,19 +47,31 @@
 #pragma mark - Custom Setters/Getters
 
 - (void)setResult:(id)result {
-    [self.task setResult:result];
+    if (![self.task trySetResult:result]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Cannot set the result on a completed task."];
+    }
 }
 
 - (void)setError:(NSError *)error {
-    [self.task setError:error];
+    if (![self.task trySetError:error]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Cannot set the error on a completed task."];
+    }
 }
 
 - (void)setException:(NSException *)exception {
-    [self.task setException:exception];
+    if (![self.task trySetException:exception]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Cannot set the exception on a completed task."];
+    }
 }
 
 - (void)cancel {
-    [self.task cancel];
+    if (![self.task trySetCancelled]) {
+        [NSException raise:NSInternalInconsistencyException
+                    format:@"Cannot cancel a completed task."];
+    }
 }
 
 - (BOOL)trySetResult:(id)result {


### PR DESCRIPTION
Move the code over, remove from private interface inside BFTaskCompletionSource.
As a result - we have 1 stack frame less in the stack trace when debugging.