### PR TITLE
Recreate Bolts-iOS target to unbreak building via subproject reference.

### DIFF
--- a/Bolts.xcodeproj/project.pbxproj
+++ b/Bolts.xcodeproj/project.pbxproj
@@ -15,38 +15,19 @@
 		1EC3017118CDAA8400D06D07 /* AppDelegate.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EC3017018CDAA8400D06D07 /* AppDelegate.m */; };
 		1EC3017318CDAA8400D06D07 /* Images.xcassets in Resources */ = {isa = PBXBuildFile; fileRef = 1EC3017218CDAA8400D06D07 /* Images.xcassets */; };
 		1EC3019118CDABCE00D06D07 /* AppLinkTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 1EC3019018CDABCE00D06D07 /* AppLinkTests.m */; };
-		7C60AEBF1ACF08F300747DD7 /* BFCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEBD1ACF08F300747DD7 /* BFCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C60AEC01ACF08F300747DD7 /* BFCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEBE1ACF08F300747DD7 /* BFCancellationToken.m */; };
-		7C60AEC31ACF093D00747DD7 /* BFCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEC11ACF093D00747DD7 /* BFCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7C60AEC41ACF093D00747DD7 /* BFCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC21ACF093D00747DD7 /* BFCancellationTokenSource.m */; };
 		7C60AEC61ACF19F900747DD7 /* CancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC51ACF19F900747DD7 /* CancellationTests.m */; };
 		7C60AEC71ACF19FD00747DD7 /* CancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC51ACF19F900747DD7 /* CancellationTests.m */; };
 		7C60AEC81ACF1A0100747DD7 /* BFCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEBD1ACF08F300747DD7 /* BFCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7C60AEC91ACF1A0900747DD7 /* BFCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEBE1ACF08F300747DD7 /* BFCancellationToken.m */; };
 		7C60AECA1ACF1A0B00747DD7 /* BFCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEC11ACF093D00747DD7 /* BFCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7C60AECB1ACF1A0D00747DD7 /* BFCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC21ACF093D00747DD7 /* BFCancellationTokenSource.m */; };
-		7CA39C921ADE715400DD78CC /* BFCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CA39C901ADE715400DD78CC /* BFCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		7CA39C931ADE715400DD78CC /* BFCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CA39C901ADE715400DD78CC /* BFCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		7CA39C941ADE715400DD78CC /* BFCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA39C911ADE715400DD78CC /* BFCancellationTokenRegistration.m */; };
 		7CA39C951ADE715400DD78CC /* BFCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA39C911ADE715400DD78CC /* BFCancellationTokenRegistration.m */; };
-		8103FA6819900A84000BAE3F /* BFExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA4F19900A84000BAE3F /* BFExecutor.m */; };
 		8103FA6919900A84000BAE3F /* BFExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA4F19900A84000BAE3F /* BFExecutor.m */; };
-		8103FA6A19900A84000BAE3F /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
 		8103FA6B19900A84000BAE3F /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
-		8103FA6C19900A84000BAE3F /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
 		8103FA6D19900A84000BAE3F /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
-		8103FA6E19900A84000BAE3F /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
 		8103FA6F19900A84000BAE3F /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
-		8103FA7019900A84000BAE3F /* BFAppLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5919900A84000BAE3F /* BFAppLink.m */; };
-		8103FA7219900A84000BAE3F /* BFAppLinkNavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5B19900A84000BAE3F /* BFAppLinkNavigation.m */; };
-		8103FA7419900A84000BAE3F /* BFAppLinkReturnToRefererController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5E19900A84000BAE3F /* BFAppLinkReturnToRefererController.m */; };
-		8103FA7619900A84000BAE3F /* BFAppLinkReturnToRefererView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6019900A84000BAE3F /* BFAppLinkReturnToRefererView.m */; };
-		8103FA7819900A84000BAE3F /* BFAppLinkTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6319900A84000BAE3F /* BFAppLinkTarget.m */; };
-		8103FA7A19900A84000BAE3F /* BFURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6519900A84000BAE3F /* BFURL.m */; };
-		8103FA7C19900A84000BAE3F /* BFWebViewAppLinkResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6719900A84000BAE3F /* BFWebViewAppLinkResolver.m */; };
-		8105DA251B7A83BC0092AE4F /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8105DA261B7A83BC0092AE4F /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		8122B2871AA0C6890025C5AF /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDDA63517E17DDD00655F8A /* Bolts.framework */; };
 		8178F9861BB0F87700AD289D /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
 		8178F9871BB0F87700AD289D /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
 		8178F9881BB0F87700AD289D /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
@@ -65,27 +46,52 @@
 		8178F9971BB0F87700AD289D /* Bolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5419900A84000BAE3F /* Bolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		8178F9981BB0F87700AD289D /* BFCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEBD1ACF08F300747DD7 /* BFCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE7D19AFA8260000AE75 /* UIKit.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81D0EE7C19AFA8260000AE75 /* UIKit.framework */; };
-		81D0EE8019AFA9E20000AE75 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE8219AFAA060000AE75 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE8319AFAA0E0000AE75 /* Bolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5419900A84000BAE3F /* Bolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8419AFAA100000AE75 /* Bolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5419900A84000BAE3F /* Bolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE8519AFAA190000AE75 /* BFTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5019900A84000BAE3F /* BFTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8619AFAA1C0000AE75 /* BFTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5019900A84000BAE3F /* BFTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8719AFAA220000AE75 /* BFExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA4E19900A84000BAE3F /* BFExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE8819AFAA240000AE75 /* BFExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA4E19900A84000BAE3F /* BFExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8919AFAA2B0000AE75 /* BFTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5219900A84000BAE3F /* BFTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81D0EE8A19AFAA2C0000AE75 /* BFTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5219900A84000BAE3F /* BFTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8C19AFAA5F0000AE75 /* BFAppLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5819900A84000BAE3F /* BFAppLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8D19AFAA5F0000AE75 /* BFAppLinkNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5A19900A84000BAE3F /* BFAppLinkNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8E19AFAA5F0000AE75 /* BFAppLinkResolving.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5C19900A84000BAE3F /* BFAppLinkResolving.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE8F19AFAA5F0000AE75 /* BFAppLinkReturnToRefererController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5D19900A84000BAE3F /* BFAppLinkReturnToRefererController.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE9019AFAA5F0000AE75 /* BFAppLinkReturnToRefererView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5F19900A84000BAE3F /* BFAppLinkReturnToRefererView.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE9119AFAA6F0000AE75 /* BFAppLinkTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6219900A84000BAE3F /* BFAppLinkTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE9219AFAA6F0000AE75 /* BFMeasurementEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAB819A567660097ECAE /* BFMeasurementEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE9319AFAA6F0000AE75 /* BFURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6419900A84000BAE3F /* BFURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
-		81D0EE9419AFAA6F0000AE75 /* BFWebViewAppLinkResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6619900A84000BAE3F /* BFWebViewAppLinkResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
 		81DC1A621B7A7F4000F491DC /* ExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DC1A611B7A7F4000F491DC /* ExecutorTests.m */; };
 		81DC1A631B7A7F4000F491DC /* ExecutorTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 81DC1A611B7A7F4000F491DC /* ExecutorTests.m */; };
+		81ED94131BE147CF00795F05 /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
+		81ED94141BE147CF00795F05 /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
+		81ED94151BE147CF00795F05 /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
+		81ED94161BE147CF00795F05 /* BFCancellationTokenRegistration.m in Sources */ = {isa = PBXBuildFile; fileRef = 7CA39C911ADE715400DD78CC /* BFCancellationTokenRegistration.m */; };
+		81ED94171BE147CF00795F05 /* BFCancellationTokenSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC21ACF093D00747DD7 /* BFCancellationTokenSource.m */; };
+		81ED94181BE147CF00795F05 /* BFExecutor.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA4F19900A84000BAE3F /* BFExecutor.m */; };
+		81ED94191BE147CF00795F05 /* BFCancellationToken.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEBE1ACF08F300747DD7 /* BFCancellationToken.m */; };
+		81ED941B1BE147CF00795F05 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
+		81ED941D1BE147CF00795F05 /* BFCancellationTokenRegistration.h in Headers */ = {isa = PBXBuildFile; fileRef = 7CA39C901ADE715400DD78CC /* BFCancellationTokenRegistration.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED941E1BE147CF00795F05 /* BFTask.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5019900A84000BAE3F /* BFTask.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED941F1BE147CF00795F05 /* BFCancellationTokenSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEC11ACF093D00747DD7 /* BFCancellationTokenSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94201BE147CF00795F05 /* BFExecutor.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA4E19900A84000BAE3F /* BFExecutor.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94211BE147CF00795F05 /* BFDefines.h in Headers */ = {isa = PBXBuildFile; fileRef = 8105DA241B7A83BC0092AE4F /* BFDefines.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94221BE147CF00795F05 /* BFTaskCompletionSource.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5219900A84000BAE3F /* BFTaskCompletionSource.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94231BE147CF00795F05 /* BoltsVersion.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5619900A84000BAE3F /* BoltsVersion.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94241BE147CF00795F05 /* Bolts.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5419900A84000BAE3F /* Bolts.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94251BE147CF00795F05 /* BFCancellationToken.h in Headers */ = {isa = PBXBuildFile; fileRef = 7C60AEBD1ACF08F300747DD7 /* BFCancellationToken.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED942B1BE1481900795F05 /* BFAppLink_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAB719A567660097ECAE /* BFAppLink_Internal.h */; };
+		81ED942C1BE1481900795F05 /* BFAppLink.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5819900A84000BAE3F /* BFAppLink.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED942D1BE1481900795F05 /* BFAppLink.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5919900A84000BAE3F /* BFAppLink.m */; };
+		81ED942E1BE1481900795F05 /* BFAppLinkNavigation.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5A19900A84000BAE3F /* BFAppLinkNavigation.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED942F1BE1481900795F05 /* BFAppLinkNavigation.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5B19900A84000BAE3F /* BFAppLinkNavigation.m */; };
+		81ED94301BE1481900795F05 /* BFAppLinkResolving.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5C19900A84000BAE3F /* BFAppLinkResolving.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94311BE1481900795F05 /* BFWebViewAppLinkResolver.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6619900A84000BAE3F /* BFWebViewAppLinkResolver.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94321BE1481900795F05 /* BFWebViewAppLinkResolver.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6719900A84000BAE3F /* BFWebViewAppLinkResolver.m */; };
+		81ED94331BE1481900795F05 /* BFAppLinkReturnToRefererController.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5D19900A84000BAE3F /* BFAppLinkReturnToRefererController.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94341BE1481900795F05 /* BFAppLinkReturnToRefererController.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5E19900A84000BAE3F /* BFAppLinkReturnToRefererController.m */; };
+		81ED94351BE1481900795F05 /* BFAppLinkReturnToRefererView.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA5F19900A84000BAE3F /* BFAppLinkReturnToRefererView.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94361BE1481900795F05 /* BFAppLinkReturnToRefererView.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6019900A84000BAE3F /* BFAppLinkReturnToRefererView.m */; };
+		81ED94371BE1481900795F05 /* BFAppLinkReturnToRefererView_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6119900A84000BAE3F /* BFAppLinkReturnToRefererView_Internal.h */; };
+		81ED94381BE1481900795F05 /* BFAppLinkTarget.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6219900A84000BAE3F /* BFAppLinkTarget.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED94391BE1481900795F05 /* BFAppLinkTarget.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6319900A84000BAE3F /* BFAppLinkTarget.m */; };
+		81ED943A1BE1481900795F05 /* BFMeasurementEvent_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAC019A599CD0097ECAE /* BFMeasurementEvent_Internal.h */; };
+		81ED943B1BE1481900795F05 /* BFMeasurementEvent.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FAB819A567660097ECAE /* BFMeasurementEvent.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED943C1BE1481900795F05 /* BFMeasurementEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = B242FAB919A567660097ECAE /* BFMeasurementEvent.m */; };
+		81ED943D1BE1481900795F05 /* BFURL_Internal.h in Headers */ = {isa = PBXBuildFile; fileRef = B242FABA19A567660097ECAE /* BFURL_Internal.h */; };
+		81ED943E1BE1481900795F05 /* BFURL.h in Headers */ = {isa = PBXBuildFile; fileRef = 8103FA6419900A84000BAE3F /* BFURL.h */; settings = {ATTRIBUTES = (Public, ); }; };
+		81ED943F1BE1481900795F05 /* BFURL.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA6519900A84000BAE3F /* BFURL.m */; };
+		81ED946F1BE14B6000795F05 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 81ED94291BE147CF00795F05 /* Bolts.framework */; };
 		85D5138A18E4E45800D19D87 /* AppLinkReturnToRefererViewTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 85D5138918E4E45800D19D87 /* AppLinkReturnToRefererViewTests.m */; };
 		8E17EC271805D0A40049E862 /* BoltsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA6BF681805CF5600337041 /* BoltsTests.m */; };
 		8E8C8EEA17F23D1D00E3F1C7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E8C8ED217F23C3B00E3F1C7 /* XCTest.framework */; };
@@ -93,11 +99,8 @@
 		8E8C8EFB17F23E5F00E3F1C7 /* TaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C3D1C17DE9F6500427E62 /* TaskTests.m */; };
 		8E8C8F1A17F241DA00E3F1C7 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E8C8ED217F23C3B00E3F1C7 /* XCTest.framework */; };
 		8E8C8F2917F241FF00E3F1C7 /* TaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C3D1C17DE9F6500427E62 /* TaskTests.m */; };
-		8E8C8F2A17F2420400E3F1C7 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDDA63517E17DDD00655F8A /* Bolts.framework */; };
-		8E9C3CED17DE9DE000427E62 /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
 		8EA6BF691805CF5600337041 /* BoltsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA6BF681805CF5600337041 /* BoltsTests.m */; };
 		8EDDA63017E17DDC00655F8A /* Foundation.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E9C3CEC17DE9DE000427E62 /* Foundation.framework */; };
-		B242FABB19A567660097ECAE /* BFMeasurementEvent.m in Sources */ = {isa = PBXBuildFile; fileRef = B242FAB919A567660097ECAE /* BFMeasurementEvent.m */; };
 		F5AFC9EC1BA752750076E927 /* BFTaskCompletionSource.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5319900A84000BAE3F /* BFTaskCompletionSource.m */; };
 		F5AFC9ED1BA752750076E927 /* BFTask.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5119900A84000BAE3F /* BFTask.m */; };
 		F5AFC9EE1BA752750076E927 /* Bolts.m in Sources */ = {isa = PBXBuildFile; fileRef = 8103FA5519900A84000BAE3F /* Bolts.m */; };
@@ -119,7 +122,6 @@
 		F5AFCA091BA752770076E927 /* BoltsTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8EA6BF681805CF5600337041 /* BoltsTests.m */; };
 		F5AFCA0A1BA752770076E927 /* TaskTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 8E9C3D1C17DE9F6500427E62 /* TaskTests.m */; };
 		F5AFCA0B1BA752770076E927 /* CancellationTests.m in Sources */ = {isa = PBXBuildFile; fileRef = 7C60AEC51ACF19F900747DD7 /* CancellationTests.m */; };
-		F5AFCA0D1BA752770076E927 /* Bolts.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8EDDA63517E17DDD00655F8A /* Bolts.framework */; };
 		F5AFCA0E1BA752770076E927 /* XCTest.framework in Frameworks */ = {isa = PBXBuildFile; fileRef = 8E8C8ED217F23C3B00E3F1C7 /* XCTest.framework */; };
 /* End PBXBuildFile section */
 
@@ -130,13 +132,6 @@
 			proxyType = 1;
 			remoteGlobalIDString = 1EC3015F18CDAA8300D06D07;
 			remoteInfo = BoltsTestUI;
-		};
-		8E8C8EF617F23D1D00E3F1C7 /* PBXContainerItemProxy */ = {
-			isa = PBXContainerItemProxy;
-			containerPortal = 8E9C3CE117DE9DE000427E62 /* Project object */;
-			proxyType = 1;
-			remoteGlobalIDString = 8E9C3CE817DE9DE000427E62;
-			remoteInfo = Bolts;
 		};
 		8E8C8F2417F241DA00E3F1C7 /* PBXContainerItemProxy */ = {
 			isa = PBXContainerItemProxy;
@@ -219,6 +214,8 @@
 		8178F99E1BB0F8A600AD289D /* watchOS-Info.plist */ = {isa = PBXFileReference; lastKnownFileType = text.plist.xml; name = "watchOS-Info.plist"; path = "Resources/watchOS-Info.plist"; sourceTree = "<group>"; };
 		81D0EE7C19AFA8260000AE75 /* UIKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = UIKit.framework; path = Platforms/iPhoneOS.platform/Developer/SDKs/iPhoneOS7.1.sdk/System/Library/Frameworks/UIKit.framework; sourceTree = DEVELOPER_DIR; };
 		81DC1A611B7A7F4000F491DC /* ExecutorTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = ExecutorTests.m; sourceTree = "<group>"; };
+		81ED94291BE147CF00795F05 /* Bolts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bolts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
+		81ED946E1BE14B5200795F05 /* Bolts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bolts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		81F0E88D19E5CB5A00812A88 /* Mac-Info.plist */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = text.plist.xml; name = "Mac-Info.plist"; path = "Resources/Mac-Info.plist"; sourceTree = "<group>"; };
 		8550FD2E18EE1B7A00976B4B /* en */ = {isa = PBXFileReference; lastKnownFileType = text.plist.strings; name = en; path = en.lproj/Localizable.strings; sourceTree = "<group>"; };
 		85D5138918E4E45800D19D87 /* AppLinkReturnToRefererViewTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = AppLinkReturnToRefererViewTests.m; sourceTree = "<group>"; };
@@ -232,7 +229,6 @@
 		8E9C3CFB17DE9DE000427E62 /* SenTestingKit.framework */ = {isa = PBXFileReference; lastKnownFileType = wrapper.framework; name = SenTestingKit.framework; path = Library/Frameworks/SenTestingKit.framework; sourceTree = DEVELOPER_DIR; };
 		8E9C3D1C17DE9F6500427E62 /* TaskTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = TaskTests.m; sourceTree = "<group>"; };
 		8EA6BF681805CF5600337041 /* BoltsTests.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BoltsTests.m; sourceTree = "<group>"; };
-		8EDDA63517E17DDD00655F8A /* Bolts.framework */ = {isa = PBXFileReference; explicitFileType = wrapper.framework; includeInIndex = 0; path = Bolts.framework; sourceTree = BUILT_PRODUCTS_DIR; };
 		B242FAB719A567660097ECAE /* BFAppLink_Internal.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BFAppLink_Internal.h; sourceTree = "<group>"; };
 		B242FAB819A567660097ECAE /* BFMeasurementEvent.h */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.h; path = BFMeasurementEvent.h; sourceTree = "<group>"; };
 		B242FAB919A567660097ECAE /* BFMeasurementEvent.m */ = {isa = PBXFileReference; fileEncoding = 4; lastKnownFileType = sourcecode.c.objc; path = BFMeasurementEvent.m; sourceTree = "<group>"; };
@@ -265,11 +261,19 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		81ED941A1BE147CF00795F05 /* Frameworks */ = {
+			isa = PBXFrameworksBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				81ED941B1BE147CF00795F05 /* Foundation.framework in Frameworks */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8E8C8EE617F23D1D00E3F1C7 /* Frameworks */ = {
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8122B2871AA0C6890025C5AF /* Bolts.framework in Frameworks */,
+				81ED946F1BE14B6000795F05 /* Bolts.framework in Frameworks */,
 				8E8C8EEA17F23D1D00E3F1C7 /* XCTest.framework in Frameworks */,
 				8E8C8EEB17F23D1D00E3F1C7 /* Foundation.framework in Frameworks */,
 			);
@@ -279,16 +283,7 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				8E8C8F2A17F2420400E3F1C7 /* Bolts.framework in Frameworks */,
 				8E8C8F1A17F241DA00E3F1C7 /* XCTest.framework in Frameworks */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8E9C3CE617DE9DE000427E62 /* Frameworks */ = {
-			isa = PBXFrameworksBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8E9C3CED17DE9DE000427E62 /* Foundation.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -312,7 +307,6 @@
 			isa = PBXFrameworksBuildPhase;
 			buildActionMask = 2147483647;
 			files = (
-				F5AFCA0D1BA752770076E927 /* Bolts.framework in Frameworks */,
 				F5AFCA0E1BA752770076E927 /* XCTest.framework in Frameworks */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
@@ -491,13 +485,14 @@
 			isa = PBXGroup;
 			children = (
 				8E9C3CE917DE9DE000427E62 /* libBolts.a */,
-				8EDDA63517E17DDD00655F8A /* Bolts.framework */,
 				8E8C8EE917F23D1D00E3F1C7 /* BoltsTests-iOS.xctest */,
 				8E8C8F1917F241DA00E3F1C7 /* BoltsTests-OSX.xctest */,
 				1EC3016018CDAA8400D06D07 /* BoltsTestUI.app */,
 				F5AFCA021BA752750076E927 /* Bolts.framework */,
 				F5AFCA131BA752770076E927 /* BoltsTests-tvOS.xctest */,
 				8178F99C1BB0F87700AD289D /* Bolts.framework */,
+				81ED94291BE147CF00795F05 /* Bolts.framework */,
+				81ED946E1BE14B5200795F05 /* Bolts.framework */,
 			);
 			name = Products;
 			sourceTree = "<group>";
@@ -556,31 +551,6 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
-		81D0EE7F19AFA9BC0000AE75 /* Headers */ = {
-			isa = PBXHeadersBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				81D0EE9419AFAA6F0000AE75 /* BFWebViewAppLinkResolver.h in Headers */,
-				81D0EE8D19AFAA5F0000AE75 /* BFAppLinkNavigation.h in Headers */,
-				81D0EE8619AFAA1C0000AE75 /* BFTask.h in Headers */,
-				81D0EE8F19AFAA5F0000AE75 /* BFAppLinkReturnToRefererController.h in Headers */,
-				81D0EE8E19AFAA5F0000AE75 /* BFAppLinkResolving.h in Headers */,
-				81D0EE9019AFAA5F0000AE75 /* BFAppLinkReturnToRefererView.h in Headers */,
-				81D0EE8719AFAA220000AE75 /* BFExecutor.h in Headers */,
-				81D0EE8919AFAA2B0000AE75 /* BFTaskCompletionSource.h in Headers */,
-				7C60AEC31ACF093D00747DD7 /* BFCancellationTokenSource.h in Headers */,
-				81D0EE9119AFAA6F0000AE75 /* BFAppLinkTarget.h in Headers */,
-				81D0EE8019AFA9E20000AE75 /* BoltsVersion.h in Headers */,
-				81D0EE8C19AFAA5F0000AE75 /* BFAppLink.h in Headers */,
-				81D0EE9219AFAA6F0000AE75 /* BFMeasurementEvent.h in Headers */,
-				8105DA251B7A83BC0092AE4F /* BFDefines.h in Headers */,
-				81D0EE9319AFAA6F0000AE75 /* BFURL.h in Headers */,
-				7CA39C921ADE715400DD78CC /* BFCancellationTokenRegistration.h in Headers */,
-				81D0EE8419AFAA100000AE75 /* Bolts.h in Headers */,
-				7C60AEBF1ACF08F300747DD7 /* BFCancellationToken.h in Headers */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
 		81D0EE8119AFA9EE0000AE75 /* Headers */ = {
 			isa = PBXHeadersBuildPhase;
 			buildActionMask = 2147483647;
@@ -594,6 +564,35 @@
 				81D0EE8219AFAA060000AE75 /* BoltsVersion.h in Headers */,
 				81D0EE8319AFAA0E0000AE75 /* Bolts.h in Headers */,
 				7C60AEC81ACF1A0100747DD7 /* BFCancellationToken.h in Headers */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
+		81ED941C1BE147CF00795F05 /* Headers */ = {
+			isa = PBXHeadersBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				81ED94311BE1481900795F05 /* BFWebViewAppLinkResolver.h in Headers */,
+				81ED941D1BE147CF00795F05 /* BFCancellationTokenRegistration.h in Headers */,
+				81ED941E1BE147CF00795F05 /* BFTask.h in Headers */,
+				81ED942E1BE1481900795F05 /* BFAppLinkNavigation.h in Headers */,
+				81ED94351BE1481900795F05 /* BFAppLinkReturnToRefererView.h in Headers */,
+				81ED941F1BE147CF00795F05 /* BFCancellationTokenSource.h in Headers */,
+				81ED94201BE147CF00795F05 /* BFExecutor.h in Headers */,
+				81ED94381BE1481900795F05 /* BFAppLinkTarget.h in Headers */,
+				81ED94211BE147CF00795F05 /* BFDefines.h in Headers */,
+				81ED943D1BE1481900795F05 /* BFURL_Internal.h in Headers */,
+				81ED94301BE1481900795F05 /* BFAppLinkResolving.h in Headers */,
+				81ED94371BE1481900795F05 /* BFAppLinkReturnToRefererView_Internal.h in Headers */,
+				81ED943E1BE1481900795F05 /* BFURL.h in Headers */,
+				81ED94221BE147CF00795F05 /* BFTaskCompletionSource.h in Headers */,
+				81ED94231BE147CF00795F05 /* BoltsVersion.h in Headers */,
+				81ED943A1BE1481900795F05 /* BFMeasurementEvent_Internal.h in Headers */,
+				81ED943B1BE1481900795F05 /* BFMeasurementEvent.h in Headers */,
+				81ED942B1BE1481900795F05 /* BFAppLink_Internal.h in Headers */,
+				81ED94241BE147CF00795F05 /* Bolts.h in Headers */,
+				81ED94251BE147CF00795F05 /* BFCancellationToken.h in Headers */,
+				81ED942C1BE1481900795F05 /* BFAppLink.h in Headers */,
+				81ED94331BE1481900795F05 /* BFAppLinkReturnToRefererController.h in Headers */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -650,6 +649,23 @@
 			productReference = 8178F99C1BB0F87700AD289D /* Bolts.framework */;
 			productType = "com.apple.product-type.framework";
 		};
+		81ED94111BE147CF00795F05 /* Bolts-iOS */ = {
+			isa = PBXNativeTarget;
+			buildConfigurationList = 81ED94261BE147CF00795F05 /* Build configuration list for PBXNativeTarget "Bolts-iOS" */;
+			buildPhases = (
+				81ED94121BE147CF00795F05 /* Sources */,
+				81ED941A1BE147CF00795F05 /* Frameworks */,
+				81ED941C1BE147CF00795F05 /* Headers */,
+			);
+			buildRules = (
+			);
+			dependencies = (
+			);
+			name = "Bolts-iOS";
+			productName = Bolts;
+			productReference = 81ED94291BE147CF00795F05 /* Bolts.framework */;
+			productType = "com.apple.product-type.framework";
+		};
 		8E8C8EE817F23D1D00E3F1C7 /* BoltsTests-iOS */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8E8C8EF817F23D1D00E3F1C7 /* Build configuration list for PBXNativeTarget "BoltsTests-iOS" */;
@@ -662,7 +678,6 @@
 			);
 			dependencies = (
 				1E617A8A18DA0CA90056A4E2 /* PBXTargetDependency */,
-				8E8C8EF717F23D1D00E3F1C7 /* PBXTargetDependency */,
 			);
 			name = "BoltsTests-iOS";
 			productName = BoltsTests;
@@ -687,23 +702,6 @@
 			productReference = 8E8C8F1917F241DA00E3F1C7 /* BoltsTests-OSX.xctest */;
 			productType = "com.apple.product-type.bundle.unit-test";
 		};
-		8E9C3CE817DE9DE000427E62 /* Bolts-iOS */ = {
-			isa = PBXNativeTarget;
-			buildConfigurationList = 8E9C3D0E17DE9DE000427E62 /* Build configuration list for PBXNativeTarget "Bolts-iOS" */;
-			buildPhases = (
-				81D0EE7F19AFA9BC0000AE75 /* Headers */,
-				8E9C3CE517DE9DE000427E62 /* Sources */,
-				8E9C3CE617DE9DE000427E62 /* Frameworks */,
-			);
-			buildRules = (
-			);
-			dependencies = (
-			);
-			name = "Bolts-iOS";
-			productName = Bolts;
-			productReference = 8EDDA63517E17DDD00655F8A /* Bolts.framework */;
-			productType = "com.apple.product-type.framework";
-		};
 		8EDDA62817E17DDC00655F8A /* Bolts-OSX */ = {
 			isa = PBXNativeTarget;
 			buildConfigurationList = 8EDDA63217E17DDC00655F8A /* Build configuration list for PBXNativeTarget "Bolts-OSX" */;
@@ -718,7 +716,7 @@
 			);
 			name = "Bolts-OSX";
 			productName = Bolts;
-			productReference = 8EDDA63517E17DDD00655F8A /* Bolts.framework */;
+			productReference = 81ED946E1BE14B5200795F05 /* Bolts.framework */;
 			productType = "com.apple.product-type.framework";
 		};
 		F5AFC9EA1BA752750076E927 /* Bolts-tvOS */ = {
@@ -782,7 +780,7 @@
 			projectDirPath = "";
 			projectRoot = "";
 			targets = (
-				8E9C3CE817DE9DE000427E62 /* Bolts-iOS */,
+				81ED94111BE147CF00795F05 /* Bolts-iOS */,
 				8EDDA62817E17DDC00655F8A /* Bolts-OSX */,
 				F5AFC9EA1BA752750076E927 /* Bolts-tvOS */,
 				8178F9841BB0F87700AD289D /* Bolts-watchOS */,
@@ -852,6 +850,28 @@
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
+		81ED94121BE147CF00795F05 /* Sources */ = {
+			isa = PBXSourcesBuildPhase;
+			buildActionMask = 2147483647;
+			files = (
+				81ED943F1BE1481900795F05 /* BFURL.m in Sources */,
+				81ED94131BE147CF00795F05 /* BFTaskCompletionSource.m in Sources */,
+				81ED94391BE1481900795F05 /* BFAppLinkTarget.m in Sources */,
+				81ED94361BE1481900795F05 /* BFAppLinkReturnToRefererView.m in Sources */,
+				81ED94141BE147CF00795F05 /* BFTask.m in Sources */,
+				81ED94151BE147CF00795F05 /* Bolts.m in Sources */,
+				81ED94161BE147CF00795F05 /* BFCancellationTokenRegistration.m in Sources */,
+				81ED94171BE147CF00795F05 /* BFCancellationTokenSource.m in Sources */,
+				81ED943C1BE1481900795F05 /* BFMeasurementEvent.m in Sources */,
+				81ED94321BE1481900795F05 /* BFWebViewAppLinkResolver.m in Sources */,
+				81ED942F1BE1481900795F05 /* BFAppLinkNavigation.m in Sources */,
+				81ED94341BE1481900795F05 /* BFAppLinkReturnToRefererController.m in Sources */,
+				81ED942D1BE1481900795F05 /* BFAppLink.m in Sources */,
+				81ED94181BE147CF00795F05 /* BFExecutor.m in Sources */,
+				81ED94191BE147CF00795F05 /* BFCancellationToken.m in Sources */,
+			);
+			runOnlyForDeploymentPostprocessing = 0;
+		};
 		8E8C8EE517F23D1D00E3F1C7 /* Sources */ = {
 			isa = PBXSourcesBuildPhase;
 			buildActionMask = 2147483647;
@@ -873,28 +893,6 @@
 				8E17EC271805D0A40049E862 /* BoltsTests.m in Sources */,
 				8E8C8F2917F241FF00E3F1C7 /* TaskTests.m in Sources */,
 				7C60AEC71ACF19FD00747DD7 /* CancellationTests.m in Sources */,
-			);
-			runOnlyForDeploymentPostprocessing = 0;
-		};
-		8E9C3CE517DE9DE000427E62 /* Sources */ = {
-			isa = PBXSourcesBuildPhase;
-			buildActionMask = 2147483647;
-			files = (
-				8103FA7819900A84000BAE3F /* BFAppLinkTarget.m in Sources */,
-				7CA39C941ADE715400DD78CC /* BFCancellationTokenRegistration.m in Sources */,
-				8103FA6C19900A84000BAE3F /* BFTaskCompletionSource.m in Sources */,
-				7C60AEC01ACF08F300747DD7 /* BFCancellationToken.m in Sources */,
-				8103FA7619900A84000BAE3F /* BFAppLinkReturnToRefererView.m in Sources */,
-				8103FA7419900A84000BAE3F /* BFAppLinkReturnToRefererController.m in Sources */,
-				8103FA7C19900A84000BAE3F /* BFWebViewAppLinkResolver.m in Sources */,
-				8103FA6A19900A84000BAE3F /* BFTask.m in Sources */,
-				8103FA6E19900A84000BAE3F /* Bolts.m in Sources */,
-				8103FA7019900A84000BAE3F /* BFAppLink.m in Sources */,
-				8103FA6819900A84000BAE3F /* BFExecutor.m in Sources */,
-				8103FA7A19900A84000BAE3F /* BFURL.m in Sources */,
-				7C60AEC41ACF093D00747DD7 /* BFCancellationTokenSource.m in Sources */,
-				8103FA7219900A84000BAE3F /* BFAppLinkNavigation.m in Sources */,
-				B242FABB19A567660097ECAE /* BFMeasurementEvent.m in Sources */,
 			);
 			runOnlyForDeploymentPostprocessing = 0;
 		};
@@ -944,11 +942,6 @@
 			isa = PBXTargetDependency;
 			target = 1EC3015F18CDAA8300D06D07 /* BoltsTestUI */;
 			targetProxy = 1E617A8918DA0CA90056A4E2 /* PBXContainerItemProxy */;
-		};
-		8E8C8EF717F23D1D00E3F1C7 /* PBXTargetDependency */ = {
-			isa = PBXTargetDependency;
-			target = 8E9C3CE817DE9DE000427E62 /* Bolts-iOS */;
-			targetProxy = 8E8C8EF617F23D1D00E3F1C7 /* PBXContainerItemProxy */;
 		};
 		8E8C8F2517F241DA00E3F1C7 /* PBXTargetDependency */ = {
 			isa = PBXTargetDependency;
@@ -1057,6 +1050,20 @@
 			};
 			name = Release;
 		};
+		81ED94271BE147CF00795F05 /* Debug */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */;
+			buildSettings = {
+			};
+			name = Debug;
+		};
+		81ED94281BE147CF00795F05 /* Release */ = {
+			isa = XCBuildConfiguration;
+			baseConfigurationReference = 81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */;
+			buildSettings = {
+			};
+			name = Release;
+		};
 		8E8C8EF917F23D1D00E3F1C7 /* Debug */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81279F741B9A3F06006696C2 /* BoltsTests-iOS.xcconfig */;
@@ -1095,20 +1102,6 @@
 		8E9C3D0D17DE9DE000427E62 /* Release */ = {
 			isa = XCBuildConfiguration;
 			baseConfigurationReference = 81279F811B9A3F06006696C2 /* Release.xcconfig */;
-			buildSettings = {
-			};
-			name = Release;
-		};
-		8E9C3D0F17DE9DE000427E62 /* Debug */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */;
-			buildSettings = {
-			};
-			name = Debug;
-		};
-		8E9C3D1017DE9DE000427E62 /* Release */ = {
-			isa = XCBuildConfiguration;
-			baseConfigurationReference = 81279F721B9A3F06006696C2 /* Bolts-iOS.xcconfig */;
 			buildSettings = {
 			};
 			name = Release;
@@ -1176,6 +1169,15 @@
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;
 		};
+		81ED94261BE147CF00795F05 /* Build configuration list for PBXNativeTarget "Bolts-iOS" */ = {
+			isa = XCConfigurationList;
+			buildConfigurations = (
+				81ED94271BE147CF00795F05 /* Debug */,
+				81ED94281BE147CF00795F05 /* Release */,
+			);
+			defaultConfigurationIsVisible = 0;
+			defaultConfigurationName = Release;
+		};
 		8E8C8EF817F23D1D00E3F1C7 /* Build configuration list for PBXNativeTarget "BoltsTests-iOS" */ = {
 			isa = XCConfigurationList;
 			buildConfigurations = (
@@ -1199,15 +1201,6 @@
 			buildConfigurations = (
 				8E9C3D0C17DE9DE000427E62 /* Debug */,
 				8E9C3D0D17DE9DE000427E62 /* Release */,
-			);
-			defaultConfigurationIsVisible = 0;
-			defaultConfigurationName = Release;
-		};
-		8E9C3D0E17DE9DE000427E62 /* Build configuration list for PBXNativeTarget "Bolts-iOS" */ = {
-			isa = XCConfigurationList;
-			buildConfigurations = (
-				8E9C3D0F17DE9DE000427E62 /* Debug */,
-				8E9C3D1017DE9DE000427E62 /* Release */,
 			);
 			defaultConfigurationIsVisible = 0;
 			defaultConfigurationName = Release;

--- a/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-iOS.xcscheme
+++ b/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-iOS.xcscheme
@@ -14,9 +14,23 @@
             buildForAnalyzing = "YES">
             <BuildableReference
                BuildableIdentifier = "primary"
-               BlueprintIdentifier = "8E9C3CE817DE9DE000427E62"
+               BlueprintIdentifier = "81ED94111BE147CF00795F05"
                BuildableName = "Bolts.framework"
                BlueprintName = "Bolts-iOS"
+               ReferencedContainer = "container:Bolts.xcodeproj">
+            </BuildableReference>
+         </BuildActionEntry>
+         <BuildActionEntry
+            buildForTesting = "YES"
+            buildForRunning = "NO"
+            buildForProfiling = "NO"
+            buildForArchiving = "NO"
+            buildForAnalyzing = "YES">
+            <BuildableReference
+               BuildableIdentifier = "primary"
+               BlueprintIdentifier = "8E8C8EE817F23D1D00E3F1C7"
+               BuildableName = "BoltsTests-iOS.xctest"
+               BlueprintName = "BoltsTests-iOS"
                ReferencedContainer = "container:Bolts.xcodeproj">
             </BuildableReference>
          </BuildActionEntry>
@@ -43,7 +57,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8E9C3CE817DE9DE000427E62"
+            BlueprintIdentifier = "81ED94111BE147CF00795F05"
             BuildableName = "Bolts.framework"
             BlueprintName = "Bolts-iOS"
             ReferencedContainer = "container:Bolts.xcodeproj">
@@ -65,7 +79,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8E9C3CE817DE9DE000427E62"
+            BlueprintIdentifier = "81ED94111BE147CF00795F05"
             BuildableName = "Bolts.framework"
             BlueprintName = "Bolts-iOS"
             ReferencedContainer = "container:Bolts.xcodeproj">
@@ -83,7 +97,7 @@
       <MacroExpansion>
          <BuildableReference
             BuildableIdentifier = "primary"
-            BlueprintIdentifier = "8E9C3CE817DE9DE000427E62"
+            BlueprintIdentifier = "81ED94111BE147CF00795F05"
             BuildableName = "Bolts.framework"
             BlueprintName = "Bolts-iOS"
             ReferencedContainer = "container:Bolts.xcodeproj">


### PR DESCRIPTION
Doing this to make sure Xcode project file is not corrupted and works great.
Before - there was no ability to add a target dependency on `Bolts-iOS` via sub-project reference.
After recreating the target - it works great.