### PR TITLE
Improve BFTask.continue return type when used with generics.

### DIFF
--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -91,8 +91,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  task will be finished (with result == nil).
  @param token The cancellation token (optional).
  */
-+ (instancetype)taskWithDelay:(int)millis
-            cancellationToken:(nullable BFCancellationToken *)token;
++ (instancetype)taskWithDelay:(int)millis cancellationToken:(nullable BFCancellationToken *)token;
 
 /*!
  Returns a task that will be completed after the given block completes with
@@ -104,8 +103,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-+ (instancetype)taskFromExecutor:(BFExecutor *)executor
-                       withBlock:(id (^)())block;
++ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(id (^)())block;
 
 // Properties that will be set on the task once it is completed.
 
@@ -150,7 +148,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithBlock:(BFContinuationBlock)block;
 
 /*!
  Enqueues the given block to be run once this task is complete.
@@ -164,8 +162,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithBlock:(BFContinuationBlock)block
-                cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask *)continueWithBlock:(BFContinuationBlock)block cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Enqueues the given block to be run once this task is complete.
@@ -176,8 +173,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                           withBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor withBlock:(BFContinuationBlock)block;
 /*!
  Enqueues the given block to be run once this task is complete.
  @param executor A BFExecutor responsible for determining how the
@@ -188,9 +184,9 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  his method will not be completed until that task is completed.
  */
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                               block:(BFContinuationBlock)block
-                   cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                           block:(BFContinuationBlock)block
+               cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Identical to continueWithBlock:, except that the block is only run
@@ -202,7 +198,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithSuccessBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block;
 
 /*!
  Identical to continueWithBlock:, except that the block is only run
@@ -215,8 +211,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithSuccessBlock:(BFContinuationBlock)block
-                       cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Identical to continueWithExecutor:withBlock:, except that the block
@@ -230,8 +225,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                    withSuccessBlock:(BFContinuationBlock)block;
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor withSuccessBlock:(BFContinuationBlock)block;
 
 /*!
  Identical to continueWithExecutor:withBlock:, except that the block
@@ -246,9 +240,9 @@ typedef __nullable id(^BFContinuationBlock)(BFTask BF_GENERIC(BFGenericType) *ta
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                        successBlock:(BFContinuationBlock)block
-                   cancellationToken:(nullable BFCancellationToken *)cancellationToken;
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                    successBlock:(BFContinuationBlock)block
+               cancellationToken:(nullable BFCancellationToken *)cancellationToken;
 
 /*!
  Waits until this operation is completed.

--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -313,14 +313,14 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
 
 #pragma mark - Chaining methods
 
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                           withBlock:(BFContinuationBlock)block {
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                       withBlock:(BFContinuationBlock)block {
     return [self continueWithExecutor:executor block:block cancellationToken:nil];
 }
 
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                               block:(BFContinuationBlock)block
-                   cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                           block:(BFContinuationBlock)block
+               cancellationToken:(BFCancellationToken *)cancellationToken {
     BFTaskCompletionSource *tcs = [BFTaskCompletionSource taskCompletionSource];
 
     // Capture all of the state that needs to used when the continuation is complete.
@@ -382,23 +382,23 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
     return tcs.task;
 }
 
-- (instancetype)continueWithBlock:(BFContinuationBlock)block {
+- (BFTask *)continueWithBlock:(BFContinuationBlock)block {
     return [self continueWithExecutor:[BFExecutor defaultExecutor] block:block cancellationToken:nil];
 }
 
-- (instancetype)continueWithBlock:(BFContinuationBlock)block
-                cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)continueWithBlock:(BFContinuationBlock)block
+            cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self continueWithExecutor:[BFExecutor defaultExecutor] block:block cancellationToken:cancellationToken];
 }
 
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                    withSuccessBlock:(BFContinuationBlock)block {
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                withSuccessBlock:(BFContinuationBlock)block {
     return [self continueWithExecutor:executor successBlock:block cancellationToken:nil];
 }
 
-- (instancetype)continueWithExecutor:(BFExecutor *)executor
-                        successBlock:(BFContinuationBlock)block
-                   cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)continueWithExecutor:(BFExecutor *)executor
+                    successBlock:(BFContinuationBlock)block
+               cancellationToken:(BFCancellationToken *)cancellationToken {
     if (cancellationToken.cancellationRequested) {
         return [BFTask cancelledTask];
     }
@@ -412,12 +412,12 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
     } cancellationToken:cancellationToken];
 }
 
-- (instancetype)continueWithSuccessBlock:(BFContinuationBlock)block {
+- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block {
     return [self continueWithExecutor:[BFExecutor defaultExecutor] successBlock:block cancellationToken:nil];
 }
 
-- (instancetype)continueWithSuccessBlock:(BFContinuationBlock)block
-                       cancellationToken:(BFCancellationToken *)cancellationToken {
+- (BFTask *)continueWithSuccessBlock:(BFContinuationBlock)block
+                   cancellationToken:(BFCancellationToken *)cancellationToken {
     return [self continueWithExecutor:[BFExecutor defaultExecutor] successBlock:block cancellationToken:cancellationToken];
 }
 


### PR DESCRIPTION
At the moment of continuing from a BFTask that has a generic type - using `instancetype` will re-use the same generic type, whilst this is redundant and might not be the case.

By chaining the return type back to `BFTask *` we can make sure that we still return a BFTask, but it won't have a specific generic type anymore.