### PR TITLE
Make most executor types create an autorelease pool for each individual task.

### DIFF
--- a/Bolts/Common/BFExecutor.m
+++ b/Bolts/Common/BFExecutor.m
@@ -59,7 +59,9 @@ __attribute__((noinline)) static size_t remaining_stack_size(size_t *__nonnull r
             if (remainingStackSize < (totalStackSize / 10)) {
                 dispatch_async(dispatch_get_global_queue(DISPATCH_QUEUE_PRIORITY_DEFAULT, 0), block);
             } else {
-                block();
+                @autoreleasepool {
+                    block();
+                }
             }
         }];
     });
@@ -85,7 +87,9 @@ __attribute__((noinline)) static size_t remaining_stack_size(size_t *__nonnull r
             if (![NSThread isMainThread]) {
                 dispatch_async(dispatch_get_main_queue(), block);
             } else {
-                block();
+                @autoreleasepool {
+                    block();
+                }
             }
         }];
     });


### PR DESCRIPTION
This help for cleaning up after the garbage generated by a task, and will overall help memory pressure.

Note that we're *not* creating a pool for the immediate executor, as its purpose is to execute with as few side-effects as possible.