### PR TITLE
Make BFExecutor retain operation/dispatch queue when constructed via +executorWith...

### DIFF
--- a/Bolts/Common/BFExecutor.h
+++ b/Bolts/Common/BFExecutor.h
@@ -41,12 +41,16 @@ NS_ASSUME_NONNULL_BEGIN
 
 /*!
  Returns a new executor that runs continuations on the given queue.
+ The dispatch queue is retained by the constructed executor.
+
  @param queue The instance of `dispatch_queue_t` to dispatch all continuations onto.
  */
 + (instancetype)executorWithDispatchQueue:(dispatch_queue_t)queue;
 
 /*!
  Returns a new executor that runs continuations on the given queue.
+ The operation queue is retained by the constructed executor.
+
  @param queue The instance of `NSOperationQueue` to run all continuations on.
  */
 + (instancetype)executorWithOperationQueue:(NSOperationQueue *)queue;


### PR DESCRIPTION
Use ObjC associated objects to retain these objects with unique keyes.