### PR TITLE
added support to build dynamic frameworks

### DIFF
--- a/scripts/build_framework.sh
+++ b/scripts/build_framework.sh
@@ -22,6 +22,7 @@
 # process options, valid arguments -c [Debug|Release] -n 
 BUILDCONFIGURATION=Debug
 NOEXTRAS=1
+DYNAMIC=0
 WATCHOS=0
 TVOS=0
 while getopts ":ntc:-:" OPTNAME
@@ -38,6 +39,9 @@ do
       ;;
     -)
       case "${OPTARG}" in
+        "with-dynamic")
+          DYNAMIC=1
+        ;;
         "with-watchos")
           WATCHOS=1
         ;;
@@ -124,16 +128,34 @@ function xcode_build_target() {
     || die "Xcode build failed for platform: ${1}."
 }
 
-xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}" "Bolts-iOS"
-xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "Bolts-iOS"
-xcode_build_target "macosx" "${BUILDCONFIGURATION}" "Bolts-OSX"
-if [ $WATCHOS -eq 1 ]; then
-  xcode_build_target "watchsimulator" "${BUILDCONFIGURATION}" "Bolts-watchOS"
-  xcode_build_target "watchos" "${BUILDCONFIGURATION}" "Bolts-watchOS"
+if [ $DYNAMIC -eq 1 ]; then
+  xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}" "Bolts-iOS-Dynamic"
+  xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "Bolts-iOS-Dynamic"
+else
+  xcode_build_target "iphonesimulator" "${BUILDCONFIGURATION}" "Bolts-iOS"
+  xcode_build_target "iphoneos" "${BUILDCONFIGURATION}" "Bolts-iOS"
 fi
+
+xcode_build_target "macosx" "${BUILDCONFIGURATION}" "Bolts-OSX"
+
+if [ $WATCHOS -eq 1 ]; then
+  if [ $DYNAMIC -eq 1 ]; then
+    xcode_build_target "watchsimulator" "${BUILDCONFIGURATION}" "Bolts-watchOS-Dynamic"
+    xcode_build_target "watchos" "${BUILDCONFIGURATION}" "Bolts-watchOS-Dynamic"
+  else
+    xcode_build_target "watchsimulator" "${BUILDCONFIGURATION}" "Bolts-watchOS"
+    xcode_build_target "watchos" "${BUILDCONFIGURATION}" "Bolts-watchOS"
+  fi
+fi
+
 if [ $TVOS -eq 1 ]; then
-  xcode_build_target "appletvsimulator" "${BUILDCONFIGURATION}" "Bolts-tvOS"
-  xcode_build_target "appletvos" "${BUILDCONFIGURATION}" "Bolts-tvOS"
+  if [ $DYNAMIC -eq 1 ]; then
+    xcode_build_target "appletvsimulator" "${BUILDCONFIGURATION}" "Bolts-tvOS-Dynamic"
+    xcode_build_target "appletvos" "${BUILDCONFIGURATION}" "Bolts-tvOS-Dynamic"
+  else  
+    xcode_build_target "appletvsimulator" "${BUILDCONFIGURATION}" "Bolts-tvOS"
+    xcode_build_target "appletvos" "${BUILDCONFIGURATION}" "Bolts-tvOS"
+  fi
 fi
 
 # -----------------------------------------------------------------------------

--- a/scripts/build_release.sh
+++ b/scripts/build_release.sh
@@ -22,7 +22,7 @@
 # -----------------------------------------------------------------------------
 # Call out to build .framework
 #
-. $BOLTS_SCRIPT/build_framework.sh --with-watchos --with-tvos -c Release
+. $BOLTS_SCRIPT/build_framework.sh --with-watchos --with-tvos --with-dynamic -c Release
 
 cd $BOLTS_BUILD
 zip -r --symlinks $BOLTS_DISTRIBUTION_ARCHIVE ios/ osx/ watchOS/ tvOS/


### PR DESCRIPTION
@nlutsenko I updated the build script to take another switch on the command-line to use the new build targets you added. Since this is the script which is used to build Parse this needs to build a dynamic framework before Parse can be built as dynamic.
