### PR TITLE
Fix Xcode 7.3 warnings.

### DIFF
--- a/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-iOS.xcscheme
+++ b/Bolts.xcodeproj/xcshareddata/xcschemes/Bolts-iOS.xcscheme
@@ -11,7 +11,8 @@
             buildForRunning = "YES"
             buildForProfiling = "YES"
             buildForArchiving = "YES"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "81ED94111BE147CF00795F05"
@@ -25,7 +26,8 @@
             buildForRunning = "NO"
             buildForProfiling = "NO"
             buildForArchiving = "NO"
-            buildForAnalyzing = "YES">
+            buildForAnalyzing = "YES"
+            hideIssues = "NO">
             <BuildableReference
                BuildableIdentifier = "primary"
                BlueprintIdentifier = "8E8C8EE817F23D1D00E3F1C7"

--- a/Bolts/Common/BFCancellationToken.m
+++ b/Bolts/Common/BFCancellationToken.m
@@ -13,7 +13,7 @@
 
 @interface BFCancellationToken ()
 
-@property (atomic, assign, getter=isCancellationRequested) BOOL cancellationRequested;
+@property (nonatomic, assign, getter=isCancellationRequested) BOOL cancellationRequested;
 @property (nonatomic, strong) NSMutableArray *registrations;
 @property (nonatomic, strong) NSObject *lock;
 @property (nonatomic) BOOL disposed;

--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -29,9 +29,9 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
     NSException *_exception;
 }
 
-@property (atomic, assign, readwrite, getter=isCancelled) BOOL cancelled;
-@property (atomic, assign, readwrite, getter=isFaulted) BOOL faulted;
-@property (atomic, assign, readwrite, getter=isCompleted) BOOL completed;
+@property (nonatomic, assign, readwrite, getter=isCancelled) BOOL cancelled;
+@property (nonatomic, assign, readwrite, getter=isFaulted) BOOL faulted;
+@property (nonatomic, assign, readwrite, getter=isCompleted) BOOL completed;
 
 @property (nonatomic, strong) NSObject *lock;
 @property (nonatomic, strong) NSCondition *condition;


### PR DESCRIPTION
These should be `nonatomic` anyway, since the public declaration lists them as such.
Fixes #215.