### PR TITLE
Remove nonnull requirement from BFTask.taskFromExecutor(_ ,block:).

### DIFF
--- a/Bolts/Common/BFTask.h
+++ b/Bolts/Common/BFTask.h
@@ -107,7 +107,7 @@ typedef __nullable id(^BFContinuationBlock)(BFTask<ResultType> *task);
  If block returns a BFTask, then the task returned from
  this method will not be completed until that task is completed.
  */
-+ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(id (^)())block;
++ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(nullable id (^)())block;
 
 // Properties that will be set on the task once it is completed.
 

--- a/Bolts/Common/BFTask.m
+++ b/Bolts/Common/BFTask.m
@@ -199,8 +199,7 @@ NSString *const BFTaskMultipleExceptionsException = @"BFMultipleExceptionsExcept
     return tcs.task;
 }
 
-+ (instancetype)taskFromExecutor:(BFExecutor *)executor
-                       withBlock:(id (^)())block {
++ (instancetype)taskFromExecutor:(BFExecutor *)executor withBlock:(nullable id (^)())block {
     return [[self taskWithResult:nil] continueWithExecutor:executor withBlock:^id(BFTask *task) {
         return block();
     }];


### PR DESCRIPTION
It's absolutely valid to have a `nil` result of a task - adjusting this method accordingly.